### PR TITLE
Update Index.rst

### DIFF
--- a/Documentation/WhatIsTca/Index.rst
+++ b/Documentation/WhatIsTca/Index.rst
@@ -39,7 +39,7 @@ Since TYPO3 CMS 6.1, the TCA definition of a new table with the name "database-t
 extension directory :file:`Configuration/TCA/` with :file:`database-table-name.php` as filename.
 An example is :file:`EXT:sys_note/Configuration/TCA/sys_note.php`. This file will be
 found by the bootstrap code (if starting a TYPO3 request). It must return an
-array with the content of the TCA setting. The return value of any loaded
+array with the content of the TCA setting if the table is active. Or it must return FALSE for a table which is not active. The return value of any loaded
 file will be cached. So there must either be no dynamic PHP code in it or
 care must be taken to clear the system cache after each change in such files.
 


### PR DESCRIPTION
What happens if a table is not active? E.g. in tt_products you can have different relationships between articles and products. This can be configured in the Extension Manager. There are cases when the mm table between products and articles is not used at all.

/typo3_src-6.2.4/typo3/sysext/core/Classes/Utility/ExtensionManagementUtility.php:
    static protected function buildBaseTcaFromSingleFiles() {
...
                    if (
                        is_file($tcaConfigurationDirectory . '/' . $file)
                        && ($file !== '.')
                        && ($file !== '..')
                        && (substr($file, -4, 4) === '.php')
                    ) {
                        $tcaOfTable = require($tcaConfigurationDirectory . '/' . $file);
                        if (is_array($tcaOfTable)) {
                            // TCA table name is filename without .php suffix, eg 'sys_notes', not 'sys_notes.php'
                            $tcaTableName = substr($file, 0, -4);
                            $GLOBALS['TCA'][$tcaTableName] = $tcaOfTable;
                        }
...
