### PR TITLE
Update Index.rst

### DIFF
--- a/Documentation/Reference/Palettes/Index.rst
+++ b/Documentation/Reference/Palettes/Index.rst
@@ -190,6 +190,6 @@ Example
 .. code-block:: php
 
    'palettes' => array(
-      '1' => array('showitem' => 'salutation, firstname, lastname, --linebreak--, mobile, phone, fax, --linebreak--, email, email_work),
+      '1' => array('showitem' => 'salutation, firstname, lastname, --linebreak--, mobile, phone, fax, --linebreak--, email, email_work'),
    )
 


### PR DESCRIPTION
inserted a missing apostrophe at the end of the palettes array at the linebreak example