### PR TITLE
[TASK] Add exceptional case for field type group

### DIFF
--- a/Documentation/Reference/Columns/Group/Index.rst
+++ b/Documentation/Reference/Columns/Group/Index.rst
@@ -47,6 +47,7 @@ Properties
    `disallowed`_             string
    `dontRemapTablesOnCopy`_  string
    `filter`_                 array
+   `foreign\_table`_         string
    `internal\_type`_         string
    `max\_size`_              integer
    `maxitems`_               integer
@@ -338,6 +339,33 @@ filter
 
 
 .. _columns-group-properties-mm:
+
+foreign\_table
+~~~~~~~~~~~~~~
+
+.. container:: table-row
+
+   Key
+         foreign\_table
+
+   Datatype
+         string
+
+         (table name)
+
+   Description
+         The item-array will be filled with records from the table defined
+         here. The table must be configured in :code:`$TCA`.
+
+         Though not needed for the backend (:code:`$TCA`), this option needs to be
+         set if you need to resolve the relationship with Extbase persistence.
+
+   Scope
+         Proc. / Display
+
+
+
+.. _columns-select-properties-foreign-table-where:
 
 MM
 ~~


### PR DESCRIPTION
Extbase needs the foreign_field option to be set in TCA on field
type group. Otherwise the persistence cannot resolve the corresponding table.