### PR TITLE
[BUGFIX] Remove broken palette "newline" documentation

### DIFF
--- a/Documentation/Reference/Types/Index.rst
+++ b/Documentation/Reference/Types/Index.rst
@@ -219,8 +219,7 @@ showitem
          .. note::
 
             Instead of a real field name you can insert :code:`--div--` to place
-            the fields into a new tab. Furthermore using value
-            :code:`--newline--` for Part 3, will start a newline within this tab.
+            the fields into a new tab.
 
          **Example:**
 


### PR DESCRIPTION
The "--newline--" setting for part 3 was broken ever since. It was also documented wrong,
the correct setting would have been "newline" without the dashes. The underlying parsing
code dates back to Kasper's initial revision and was never touched or modified. The
according parsing code will be removed with CMS 7 and this documentation part can be
removed without substitution - also in 6.2 since it never worked anyway.