### PR TITLE
[BUGFIX] Remove broken palette "newline" documentation

### DIFF
--- a/Documentation/Reference/Types/Index.rst
+++ b/Documentation/Reference/Types/Index.rst
@@ -221,8 +221,7 @@ showitem
             Instead of a real field name you can insert :code:`--div--` and you
             should have a divider line shown. However this is not rendered by
             default. If you set the dividers2tabs option (see ['ctrl'] section),
-            each :code:`--div--` will define a new tab. Furthermore using value
-            :code:`--newline--` for Part 3, will start a newline with this tab.
+            each :code:`--div--` will define a new tab.
 
          **Example:**
 


### PR DESCRIPTION
The "--newline--" setting for part 3 was broken ever since. It was also documented wrong,
the correct setting would have been "newline" without the dashes. The underlying parsing
code dates back to Kasper's initial revision and was never touched or modified. The
according parsing code will be removed with CMS 7 and this documentation part can be
removed without substitution - also in 6.2 since it never worked anyway.