### PR TITLE
Flex: Remove currentSheetId

### DIFF
--- a/Documentation/Reference/Columns/Flex/Index.rst
+++ b/Documentation/Reference/Columns/Flex/Index.rst
@@ -557,11 +557,6 @@ Array Elements
          Meta data for the content. For instance information about which sheet
          is active etc.
 
-   Child elements
-         <currentSheetId>
-
-         <currentLangId>
-
 
 
 .. _columns-flex-data-format-array-data:
@@ -712,23 +707,6 @@ Value Elements
    Description
          Content of the field in default or localized versions
 
-
-
-.. _columns-flex-data-format-value-currentsheetid:
-
-<currentSheetId>
-''''''''''''''''
-
-.. container:: table-row
-
-   Element
-         <currentSheetId>
-
-   Format
-         string
-
-   Description
-         Points to the currently shown sheet in the DS.
 
 
 .. _columns-flex-example-simple:


### PR DESCRIPTION
currentSheetId as meta flex form field was never fully implemented
correctly in the core and is now removed.