### PR TITLE
Update Index.rst

### DIFF
--- a/Documentation/Reference/Columns/Check/Index.rst
+++ b/Documentation/Reference/Columns/Check/Index.rst
@@ -99,7 +99,7 @@ items
          If set, this array will create an array of checkboxes instead of just
          a single "on/off" checkbox.
 
-         **Notice:** You can have a maximum of 10 checkboxes in such an array
+         **Notice:** You can have a maximum of 31 checkboxes in such an array
          and each element is represented by a single bit in the integer value
          which ultimately goes into the database.
 


### PR DESCRIPTION
There is no real restriction for only 10 checkboxes as the underlying data integer (normaly int(11) in mysql) can hold 32 bit. as in reality the usage of the highest bit results in a loss of all bits, the maximum of possible checkboxes is 31.
I tested with bigint but all bits above 32 were ignored and setting bit 32 loses all bits, so I suspect a PHP restriction here.
Maybe a PHP expert who knows the differences about all php-implementations can validate if all current PHP versions work with 4Byte integers and so 31 bits are available everywhere.