### PR TITLE
[BUGFIX] Mention one table limit of foreign_table

### DIFF
--- a/Documentation/Reference/Columns/Group/Index.rst
+++ b/Documentation/Reference/Columns/Group/Index.rst
@@ -357,7 +357,9 @@ foreign\_table
          This property does not really exist for group-type fields. It is needed
          as a workaround for an Extbase limitation. It is used to resolve
          dependencies during Extbase persistence. It should hold the same values
-         as property :ref:`allowed <columns-group-properties-allowed>`.
+         as property :ref:`allowed <columns-group-properties-allowed>`. Notice that
+         only one table name is allowed here compared to the property
+         :ref:`allowed <columns-group-properties-allowed>`.
             
 
    Scope


### PR DESCRIPTION
Extbase expects "foreign_table" to contain exactly one table name compared to "allowed" which can hold a list of table names.