### PR TITLE
[TASK] Add missing blindLinkFields to the core link wizard

### DIFF
--- a/Documentation/AdditionalFeatures/CoreWizardScripts/Index.rst
+++ b/Documentation/AdditionalFeatures/CoreWizardScripts/Index.rst
@@ -697,6 +697,26 @@ blindLinkOptions
          link options are displayed.
 
 
+
+.. _core-wizards-browse-properties-blindlinkfields:
+
+blindLinkFields
+'''''''''''''''
+
+.. container:: table-row
+
+   Key
+         blindLinkFields
+
+   Type
+         string
+
+   Description
+         Comma separated list of link fields that should not be displayed.
+         Possible values are class, params, target and title. By default, all
+         link fields are displayed.
+
+
 .. _core-wizards-browse-example:
 
 Example


### PR DESCRIPTION
The link wizards also accepts which fields should be blinded,
but the documentation for this param is missing.

https://forge.typo3.org/issues/69462