### PR TITLE
Add information of palettes not collapsing in >= 7.4 version of TYPO3

### DIFF
--- a/Documentation/Reference/Palettes/Index.rst
+++ b/Documentation/Reference/Palettes/Index.rst
@@ -38,7 +38,7 @@ When a palette exists, an icon appears next to the relevant field:
 .. figure:: ../../Images/PalettesCollapsed.png
    :alt: A collapsed palette
 
-   A collapsed palette with the icon to expand it
+   A collapsed palette with the icon to expand it. With TYPO3 version 7.4 onwards the icon is not displayed and the palette expanded.
 
 Clicking on this icon, the palette is revealed:
 


### PR DESCRIPTION
Some information regarding the older collapsing was already deleted. As I just tried palettes first time I had a hard time with the current documentation. The images are still out of date. Cannot fix them myself right now.