### PR TITLE
[FIX] Inline element with foreign_table only has maxitems 1 as default

### DIFF
--- a/Documentation/Reference/Columns/Inline/Index.rst
+++ b/Documentation/Reference/Columns/Inline/Index.rst
@@ -820,6 +820,11 @@ maxitems
          that this is different from types "select" and "group" which default
          to 1.
 
+         .. note::
+
+            If the inline is used with ``foreign_table`` only, to store a
+            comma-separated list of uids, it defaults to 1.
+
    Scope
          Display / Proc
 


### PR DESCRIPTION
`maxitems` is defaulted to 1, trough `checkValue_checkMax` here: https://github.com/TYPO3/TYPO3.CMS/blob/TYPO3_6-2-15/typo3%2Fsysext%2Fcore%2FClasses%2FDataHandling%2FDataHandler.php#L2927