### PR TITLE
[TASK] Backport foreign_table appendix from master

### DIFF
--- a/Documentation/Reference/Columns/Group/Index.rst
+++ b/Documentation/Reference/Columns/Group/Index.rst
@@ -357,7 +357,9 @@ foreign\_table
          This property does not really exist for group-type fields. It is needed
          as a workaround for an Extbase limitation. It is used to resolve
          dependencies during Extbase persistence. It should hold the same values
-         as property :ref:`allowed <columns-group-properties-allowed>`.
+         as property :ref:`allowed <columns-group-properties-allowed>`. Notice that
+         only one table name is allowed here in contrast to the property
+         :ref:`allowed <columns-group-properties-allowed>` itself.
 
 
    Scope


### PR DESCRIPTION
Within "foreign_table" only a single table name is allowed while "allowed" can hold a list of table names.