### PR TITLE
Document ``disableAgeDisplay`` option

### DIFF
--- a/Documentation/Reference/Columns/Input/Index.rst
+++ b/Documentation/Reference/Columns/Input/Index.rst
@@ -530,48 +530,12 @@ disableAgeDisplay
          boolean
 
    Description
-         An array which defines an integer range within which the value must
-         be.
-
-         **Keys:**
-
-         lower
-           Defines the lower integer value.
-
-         upper
-           Defines the upper integer value.
-
-         You can specify both or only one of them.
-
-         .. note::
-
-            This feature is evaluated *on the server only* so any
-            regulation of the value will have happened after saving the form.
-
-         **Example:**
-
-         Limits an integer to be within the range 10 to 1000:
-
-         .. code-block:: php
-
-            'eval' => 'int',
-            'range' => array(
-              'lower' => 10,
-              'upper' => 1000
-            ),
-
-         In this example the upper limit is set to the last day in year 2020
-         while the lowest possible value is set to the date of yesterday.
-
-         .. code-block:: php
-
-            'range' => array(
-              'upper' => mktime(0, 0, 0, 12, 31, 2020),
-              'lower' => mktime(0,0,0,date('m'), date('d'), date('Y'))
-            )
+         Disable the display of the age (p.e. "2015-08-30 (-27 days)") of
+         date fields. It will be respected if the field has the type 
+         ``input`` and its eval is set to ``date``.
 
    Scope
-         Proc.
+         Display
 
 
 


### PR DESCRIPTION
Previous documentation was a copy/paste of ``range`` option which was clearly a mistake.
Description is directly taken from Changelog notes (Feature 28243)