### PR TITLE
[BUGFIX] Document default max length for input

### DIFF
--- a/Documentation/Reference/Columns/Input/Index.rst
+++ b/Documentation/Reference/Columns/Input/Index.rst
@@ -122,7 +122,7 @@ max
          Value for the "maxlength" attribute of the :code:`<input>` field.
 
          If the form element edits a varchar(40) field in the database you
-         should also set this value to 40.
+         should also set this value to 40. Default is 256.
 
    Scope
          Display


### PR DESCRIPTION
The default value for max is hardcoded to 256 which should be mentioned.