### PR TITLE
Fix wrong TCA example (common properties > search)

### DIFF
--- a/Documentation/Reference/Columns/Common/Index.rst
+++ b/Documentation/Reference/Columns/Common/Index.rst
@@ -219,11 +219,12 @@ search
                             'bodytext' => array(
                                     ...
                                     'config' => array(
-                                            ...
+                                          ...
+                                          'search' => array(
+                                                  'andWhere' => 'CType=\'text\' OR CType=\'textpic\'',
+                                          ),
+                                          ...
                                     ),
-                                    'search' => array(
-                                            'andWhere' => 'CType=\'text\' OR CType=\'textpic\'',
-                                    )
                             ),
                             ...
                     ),


### PR DESCRIPTION
The common property "search" has to be located **inside** of the config-array. It's not a sibling like the example showed before.