### PR TITLE
Fix syntax error in displayCond example code

### DIFF
--- a/Documentation/Reference/Columns/Index.rst
+++ b/Documentation/Reference/Columns/Index.rst
@@ -416,7 +416,7 @@ displayCond
 
          .. code-block:: php
 
-				'displayCond' ==> array(
+				'displayCond' => array(
 					'AND' => array(
 						'FIELD:sys_language_uid:<=:0',
 						'OR' => array(


### PR DESCRIPTION
There are two equal signs when assigning a value to an array but there must be only one.