### PR TITLE
columnsOverride was missing config level

### DIFF
--- a/Documentation/Reference/Types/Index.rst
+++ b/Documentation/Reference/Types/Index.rst
@@ -264,8 +264,10 @@ columnsOverrides
 					'showitem' => 'hidden, myText'
 					'columnsOverrides' => array(
 						'myText' => array(
-							'defaultExtras' => 'nowrap',
-							'rows' => '__UNSET',
+							'config' => array(
+								'defaultExtras' => 'nowrap',
+								'rows' => '__UNSET',
+							),
 						),
 					),
 				),


### PR DESCRIPTION
As the columnsOverrides gets merged with the entire column config, you must also include the 'config' dimension in the array you want to overrule.