### PR TITLE
TCA Manipulations which can't be cached.

### DIFF
--- a/Documentation/ExtendingTca/StoringChanges/Index.rst
+++ b/Documentation/ExtendingTca/StoringChanges/Index.rst
@@ -91,3 +91,4 @@ It is also possible to perform some special manipulations on
 :php:`$GLOBALS['TCA']` right before it is stored into cache, thanks to the
 :code:`tcaIsBeingBuilt` signal. This signal was introduced in
 TYPO3 CMS 6.2.1.
+Put all manipulations which can not be cached (for example Page-TS-config specific or website specific TCA-manipulations) into :file:`ext_tables.php`.


### PR DESCRIPTION
It's not possible to put TCA-Manipulation-Code which isn't static (like Page-TS-config specific manipulations) in "Configuration/TCA/<tablename>.php" or "Configuration/TCA/Overrides/<tablename>.php".
You have to put it in ext_tables.php.
Is there a other way?