### PR TITLE
[BUGFIX] Fix SQL syntax error in example

### DIFF
--- a/Documentation/Reference/Columns/Select/Index.rst
+++ b/Documentation/Reference/Columns/Select/Index.rst
@@ -654,7 +654,7 @@ MM
 
               KEY uid_local (uid_local),
               KEY uid_foreign (uid_foreign),
-              PRIMARY KEY (uid),
+              PRIMARY KEY (uid)
             );
 
          The field name of the config is not used for data-storage anymore but


### PR DESCRIPTION
Table structure for table 'user_testmmrelations_two_rel_mm' has a syntax error near ')' at line 13.