### PR TITLE
Add maxItemsInResultList for SuggestWizard

### DIFF
--- a/Documentation/AdditionalFeatures/WizardsConfiguration/Index.rst
+++ b/Documentation/AdditionalFeatures/WizardsConfiguration/Index.rst
@@ -865,6 +865,25 @@ minimumCharacters
 
 
 
+.. _wizards-configuration-suggest-maxitemsinresultList:
+
+maxItemsInResultList
+''''''''''''''''''''
+
+.. container:: table-row
+
+   Key
+         maxItemsInResultList
+
+   Type
+         integer
+
+   Description
+         Maximum number of results to display, default is :code:`10`.
+
+
+
+
 .. _wizards-configuration-suggest-maxpathtitlelength:
 
 maxPathTitleLength
@@ -880,7 +899,7 @@ maxPathTitleLength
 
    Description
          Maximum number of characters to display when a path element is too
-         long
+         long.
 
 
 


### PR DESCRIPTION
Add the missing documentation of maxItemsInResultList, which has always been available.
Needs to be backported to 7.6 and 6.2.