### PR TITLE
Update custom configuration for FAL

### DIFF
--- a/Documentation/ColumnsConfig/Type/Inline.rst
+++ b/Documentation/ColumnsConfig/Type/Inline.rst
@@ -108,16 +108,19 @@ information related to existing media. Here is how it is used on the "image" fie
                 ],
                 // custom configuration for displaying fields in the overlay/reference table
                 // to use the image overlay palette instead of the basic overlay palette
-                'foreign_types' => [
-                    '0' => [
-                        'showitem' => '
-                            --palette--;LLL:EXT:lang/locallang_tca.xlf:sys_file_reference.imageoverlayPalette;imageoverlayPalette,
-                            --palette--;;filePalette'
-                    ],
-                    \TYPO3\CMS\Core\Resource\File::FILETYPE_TEXT => [
-                        'showitem' => '
-                            --palette--;LLL:EXT:lang/locallang_tca.xlf:sys_file_reference.imageoverlayPalette;imageoverlayPalette,
-                            --palette--;;filePalette'
+                'overrideChildTca' => [
+                    'types' => [
+                        '0' => [
+                            'showitem' => '
+                                    --palette--;LLL:EXT:lang/locallang_tca.xlf:sys_file_reference.imageoverlayPalette;imageoverlayPalette,
+                                    --palette--;;filePalette'
+                            ],
+                            \TYPO3\CMS\Core\Resource\File::FILETYPE_TEXT => [
+                                'showitem' => '
+                                    --palette--;LLL:EXT:lang/locallang_tca.xlf:sys_file_reference.imageoverlayPalette;imageoverlayPalette,
+                                    --palette--;;filePalette'
+                            ],
+                        ],
                     ],
                 ],
             ],


### PR DESCRIPTION
To add custom configuration for the file abstraction layer the overrideChildTca has to be used instead of foreign_types.