### PR TITLE
Missing crucial renderType in example

### DIFF
--- a/Documentation/Reference/Columns/Select/Index.rst
+++ b/Documentation/Reference/Columns/Select/Index.rst
@@ -1560,6 +1560,7 @@ The corresponding TCA configuration:
 		'label' => 'LLL:EXT:lang/locallang_general.xlf:LGL.fe_group',
 		'config' => array(
 			'type' => 'select',
+        	        'renderType' => 'selectMultipleSideBySide',
 			'size' => 5,
 			'maxitems' => 20,
 			'items' => array(


### PR DESCRIPTION
Adds crucial renderType to selectMultipleSideBySide example