### PR TITLE
Change links from t3inside to t3coreapi

### DIFF
--- a/Documentation/Columns/ColumnsExclude.rst.txt
+++ b/Documentation/Columns/ColumnsExclude.rst.txt
@@ -11,4 +11,4 @@ exclude
     If set, all backend users are prevented from editing the field unless they are members of a backend
     user group with this field added as an "Allowed Excludefield" (or "admin" user).
 
-    See :ref:`Inside TYPO3 <t3inside:start>` for more about permissions.
+    See :ref:`Access lists <t3coreapi:access-options-access-lists>` for more about permissions.

--- a/Documentation/Ctrl/CtrlTitle.rst.txt
+++ b/Documentation/Ctrl/CtrlTitle.rst.txt
@@ -18,8 +18,8 @@ title
     instead. This value is managed by the "title" value.
 
     You can insert plain text values, but the preferred way is to enter a
-    reference to a localized string. Refer to the Localization section in
-    :ref:`Inside TYPO3 <t3inside:start>` for more details.
+    reference to a localized string. Refer to the :ref:`Localization <t3coreapi:internationalization>`
+    section for more details.
 
     **Example for table "sys\_template"**
 

--- a/Documentation/Settings.cfg
+++ b/Documentation/Settings.cfg
@@ -56,7 +56,6 @@ use_opensearch       = https://docs.typo3.org/typo3cms/TCAReference
 t3coreapi  = https://docs.typo3.org/typo3cms/CoreApiReference
 t3fal      = https://docs.typo3.org/typo3cms/FileAbstractionLayerReference
 t3l10n     = https://docs.typo3.org/typo3cms/FrontendLocalizationGuide/
-t3inside   = https://docs.typo3.org/typo3cms/InsideTypo3Reference
 t3tsconfig = https://docs.typo3.org/typo3cms/TSconfigReference
 
 


### PR DESCRIPTION
Inside TYPO3 manual has been merged with TYPO3 Core API.
The references are updated.