### PR TITLE
Remove duplicate text block

### DIFF
--- a/Documentation/ColumnsConfig/Behaviour/AllowLanguageSynchronization.rst
+++ b/Documentation/ColumnsConfig/Behaviour/AllowLanguageSynchronization.rst
@@ -7,23 +7,6 @@
 allowLanguageSynchronization
 ============================
 
-.. rst-class:: dl-parameters
-
-allowLanguageSynchronization
-   :sep:`|` :aspect:`Scope:`    Proc.
-   :sep:`|` :aspect:`Datatype:` boolean
-   :sep:`|` :aspect:`Default:`  false
-   :sep:`|`
-
-   Allows an editor to select in a localized record if the value is copied over from default or source
-   language record, or if the field has an own value in the localization.
-   If set to true, and if the table supports localization and if a localized record is edited, this setting enables
-   FieldWizard :ref:`LocalizationStateSelector <columns-input-properties-fieldWizard-localizationStateSelector>`:
-   Two or three radio buttons shown below the field input.
-   The state of this is stored in a json encoded array in the database table called :code:`l10n_state`. It tells
-   the DataHandler which fields of the localization records should be kept in sync if the underlying default or
-   source record changes.
-
 .. include:: CommonAllowLanguageSynchronization.txt
 
 Example::


### PR DESCRIPTION
The removed and the included text are nearly the same. There are tiny differences ("whether" vs. "if"). So if you think I removed the wrong of them, feel free to reject my pull request and change it the other way.