### PR TITLE
Add generatorOption "replacements" to example

### DIFF
--- a/Documentation/ColumnsConfig/Type/Slug.rst
+++ b/Documentation/ColumnsConfig/Type/Slug.rst
@@ -58,6 +58,9 @@ Examples
                 'fields' => ['title', 'nav_title'],
                 'fieldSeparator' => '/',
                 'prefixParentPageSlug' => true,
+                'replacements' => [
+                    '/' => '',
+                ],
             ],
             'fallbackCharacter' => '-',
             'eval' => 'uniqueInSite',


### PR DESCRIPTION
There is a new option available for slugs in TYPO3 9.5.2 which is calle `replacements`.