### PR TITLE
Add missing comma in TCA configuration example

### DIFF
--- a/Documentation/ColumnsConfig/Type/User.rst
+++ b/Documentation/ColumnsConfig/Type/User.rst
@@ -56,7 +56,7 @@ Register an own node element::
 Use it as renderType in TCA::
 
     'myMapElement' = [
-        'label' => 'My map element'
+        'label' => 'My map element',
         'config' => [
             'type' => 'user',
             'renderType' => 'lollisCustomMapElement',


### PR DESCRIPTION
It fixes small typo in TCA sample code where comma was missing. It adds missing comma.