### PR TITLE
Correct available t3editor formats

### DIFF
--- a/Documentation/ColumnsConfig/Properties/TextFormat.rst.txt
+++ b/Documentation/ColumnsConfig/Properties/TextFormat.rst.txt
@@ -9,4 +9,4 @@ format
 
 :aspect:`Description`
     The value specifies the language t3editor should handle. Allowed values:
-    `html`, `typoscript`, `javascript`, `css`, `xml`, `html`, `php`, `sparql`, `mixed`
+    `css`, `html`, `javascript`, `php`, `typoscript`, `xml`


### PR DESCRIPTION
Current list for formats from: https://github.com/TYPO3/TYPO3.CMS/blob/master/typo3/sysext/t3editor/Configuration/Backend/T3editor/Modes.php

Corrections:
- Remove double html entry
- Remove unsupported formats sparql and mixed
- Sort alphabetically