### PR TITLE
Update cropVariants documentation of imageManipulation type

### DIFF
--- a/Documentation/ColumnsConfig/Properties/ImageManipulationCropVariants.rst.txt
+++ b/Documentation/ColumnsConfig/Properties/ImageManipulationCropVariants.rst.txt
@@ -158,3 +158,78 @@ cropVariants
                  ],
              ],
          ]
+
+    The above configuration examples are basically meant to add one single cropping configuration
+    to sys_file_reference, which will then apply in every record, which reference images.
+
+    It is however also possible to provide a configuration per content element. If you for example want a different
+    cropping configuration for tt_content images, then you can add the following to your `image` field configuration of tt_content records:
+
+    .. code-block:: php
+
+        'config' => [
+            'overrideChildTca' => [
+                'columns' => [
+                    'crop' => [
+                        'config' => [
+                            'cropVariants' => [
+                                'mobile' => [
+                                    'title' => 'LLL:EXT:ext_key/Resources/Private/Language/locallang.xlf:imageManipulation.mobile',
+                                    'cropArea' => [
+                                        'x' => 0.1,
+                                        'y' => 0.1,
+                                        'width' => 0.8,
+                                        'height' => 0.8,
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]
+
+    Please note, that you need to specify the target column name as array key. Most of the time this will be `crop`
+    as this is the default field name for image manipulation in `sys_file_reference`
+
+    It is also possible to set the cropping configuration only for a specific tt_content element type by using the
+    `columnsOverrides` feature:
+
+    .. code-block:: php
+
+        $GLOBALS['TCA']['tt_content']['types']['textmedia']['columnsOverrides']['assets']['config']['overrideChildTca']['columns']['crop']['config'] = [
+            'cropVariants' => [
+               'default' => [
+                   'disabled' => true,
+               ],
+               'mobile' => [
+                   'title' => 'LLL:EXT:ext_key/Resources/Private/Language/locallang.xlf:imageManipulation.mobile',
+                   'cropArea' => [
+                       'x' => 0.1,
+                       'y' => 0.1,
+                       'width' => 0.8,
+                       'height' => 0.8,
+                   ],
+                   'allowedAspectRatios' => [
+                       '4:3' => [
+                           'title' => 'LLL:EXT:lang/Resources/Private/Language/locallang_wizards.xlf:imwizard.ratio.4_3',
+                           'value' => 4 / 3
+                       ],
+                       'NaN' => [
+                           'title' => 'LLL:EXT:lang/Resources/Private/Language/locallang_wizards.xlf:imwizard.ratio.free',
+                           'value' => 0.0
+                       ],
+                   ],
+               ],
+            ],
+        ];
+
+    Please note, that the array for ``overrideChildTca`` is merged with the child TCA, so are the crop variants that are defined
+    in the child TCA (most likely sys_file_reference). Because you cannot remove crop variants easily, it is possible to disable them
+    for certain field types by setting the array key for a crop variant ``disabled`` to the value ``true``
+
+    To render crop variants, the variants can be specified as argument to the image view helper:
+
+    .. code-block:: html
+
+        <f:image image="{data.image}" cropVariant="mobile" width="800" />


### PR DESCRIPTION
This commit adds cropVariants documentation about configuration per content element, configuration per content element type, disabling cropVariants and using cropVariants in Fluid's image view helper.
This is just copy & paste of a few sections from TYPO3 CMS Core ChangeLog item [Feature: #75880 - Implement multiple cropping variants in image manipulation tool](https://docs.typo3.org/c/typo3/cms-core/master/en-us/Changelog/8.6/Feature-75880-ImplementMultipleCroppingVariantsInImageManipulationTool.html)