### PR TITLE
Use a different description for default values for select renderTypes…

### DIFF
--- a/Documentation/ColumnsConfig/Properties/SelectDefaultMulti.rst.txt
+++ b/Documentation/ColumnsConfig/Properties/SelectDefaultMulti.rst.txt
@@ -1,0 +1,13 @@
+default
+~~~~~~~
+
+:aspect:`Datatype`
+    string
+
+:aspect:`Scope`
+    Display / Proc.
+
+:aspect:`Description`
+    Default value set if a new record is created. For select types with
+    multiple values, use a list of comma separated values, e.g. `1` or
+    `1,2,7,12`.

--- a/Documentation/ColumnsConfig/Type/Select.rst
+++ b/Documentation/ColumnsConfig/Type/Select.rst
@@ -340,7 +340,7 @@ Renders a select field to select multiple entries from a given list.
 .. include:: ../Properties/CommonBehaviour.rst.txt
 .. include:: ../Behaviour/CommonAllowLanguageSynchronization.rst.txt
 
-.. include:: ../Properties/SelectDefault.rst.txt
+.. include:: ../Properties/SelectDefaultMulti.rst.txt
 
 .. include:: ../Properties/SelectDisableNonMatchingValueElement.rst.txt
 
@@ -421,7 +421,7 @@ Render the list of values as single check box rows in a table. Multiple items ca
 .. include:: ../Properties/CommonBehaviour.rst.txt
 .. include:: ../Behaviour/CommonAllowLanguageSynchronization.rst.txt
 
-.. include:: ../Properties/SelectDefault.rst.txt
+.. include:: ../Properties/SelectDefaultMulti.rst.txt
 
 .. include:: ../Properties/SelectDisableNonMatchingValueElement.rst.txt
 
@@ -499,7 +499,7 @@ Two select fields, items can be selected from the right field, selected items ar
 .. include:: ../Properties/CommonBehaviour.rst.txt
 .. include:: ../Behaviour/CommonAllowLanguageSynchronization.rst.txt
 
-.. include:: ../Properties/SelectDefault.rst.txt
+.. include:: ../Properties/SelectDefaultMulti.rst.txt
 
 .. include:: ../Properties/SelectDisableNonMatchingValueElement.rst.txt
 
@@ -588,7 +588,7 @@ A tree for selecting hierarchical data items.
 .. include:: ../Properties/CommonBehaviour.rst.txt
 .. include:: ../Behaviour/CommonAllowLanguageSynchronization.rst.txt
 
-.. include:: ../Properties/SelectDefault.rst.txt
+.. include:: ../Properties/SelectDefaultMulti.rst.txt
 
 .. include:: ../Properties/SelectDisableNonMatchingValueElement.rst.txt
 


### PR DESCRIPTION

There is a "default" property for "select" type:

> Default value set if a new record is created. If empty, the first element in the items array is selected.

If you can select multiple values, this is slightly off. This change uses a different description for select types with multiple values.