### PR TITLE
Update CtrlCopyAfterDuplFields.rst.txt

### DIFF
--- a/Documentation/Ctrl/CtrlCopyAfterDuplFields.rst.txt
+++ b/Documentation/Ctrl/CtrlCopyAfterDuplFields.rst.txt
@@ -9,7 +9,7 @@ copyAfterDuplFields
 
 :aspect:`Description`
     The fields in this list will automatically have the value of the same field from the "previous" record transferred
-    when they are *copied or moved* to the position *after* another record from same table.
+    when they are *copied* to the position *after* another record from same table.
 
     **Example from "tt\_content" table:**
 


### PR DESCRIPTION
Moving a record won't apply the effect of "copyAfterDuplFields" since TYPO3 9.5.