### PR TITLE
Rephrase reference to 'search' option

### DIFF
--- a/Documentation/Ctrl/CtrlSearchFields.rst.txt
+++ b/Documentation/Ctrl/CtrlSearchFields.rst.txt
@@ -11,7 +11,7 @@ searchFields
     Comma-separated list of fields from the table that will be included when searching for records in the TYPO3 backend.
     No record from a table will ever be found if that table does not have "searchFields" defined.
 
-    There are more fine grained controls per column, see the documentation of the "search" key in :ref:`columns-types`.
+    There are more fine grained controls per column, see the documentation of the "search" key of any type in :ref:`columns-types`.
 
     **Example from "tt\_content" table:**
 

--- a/Documentation/Ctrl/CtrlSearchFields.rst.txt
+++ b/Documentation/Ctrl/CtrlSearchFields.rst.txt
@@ -11,7 +11,7 @@ searchFields
     Comma-separated list of fields from the table that will be included when searching for records in the TYPO3 backend.
     No record from a table will ever be found if that table does not have "searchFields" defined.
 
-    There are more fine grained controls per column, see the "search" in this manual.
+    There are more fine grained controls per column, see the documentation of the "search" key in :ref:`columns-types`.
 
     **Example from "tt\_content" table:**
 


### PR DESCRIPTION
Make it more clear which part of the documentation is meant.