### PR TITLE
Make subproperties in columnConfig more easily visible

### DIFF
--- a/Documentation/ColumnsConfig/Behaviour/CommonAllowLanguageSynchronization.rst.txt
+++ b/Documentation/ColumnsConfig/Behaviour/CommonAllowLanguageSynchronization.rst.txt
@@ -15,5 +15,16 @@
    It tells the DataHandler which fields of the localization records should be kept
    in sync if the underlying default or source record changes.
 
+   Example::
+
+      'aField' => [
+         'config' => [
+            'type' = 'sometype',
+            'behaviour' => [
+               'allowLanguageSynchronization' => true
+            ]
+         ]
+      ]
+
 :aspect:`Default`
     false

--- a/Documentation/ColumnsConfig/Type/Flex.rst
+++ b/Documentation/ColumnsConfig/Type/Flex.rst
@@ -184,8 +184,8 @@ behaviour
 
 .. include:: ../Properties/CommonBehaviour.rst.txt
 
-allowLanguageSynchronization
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+behaviour => allowLanguageSynchronization
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. include:: ../Behaviour/CommonAllowLanguageSynchronization.rst.txt
 

--- a/Documentation/ColumnsConfig/Type/Group.rst
+++ b/Documentation/ColumnsConfig/Type/Group.rst
@@ -158,8 +158,8 @@ behaviour
 
 .. include:: ../Properties/CommonBehaviour.rst.txt
 
-allowLanguageSynchronization
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+behaviour => allowLanguageSynchronization
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. include:: ../Behaviour/CommonAllowLanguageSynchronization.rst.txt
 
@@ -191,30 +191,36 @@ fieldControl
 
 .. include:: ../Properties/CommonFieldControl.rst.txt
 
-addRecord
-~~~~~~~~~
+The following fieldControls are available for this type:
+
+.. contents::
+   :local:
+   :depth: 1
+
+fieldControl => addRecord
+~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. include:: ../FieldControl/AddRecord.rst.txt
 
-editPopup
-~~~~~~~~~
+fieldControl => editPopup
+~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. include:: ../FieldControl/EditPopup.rst.txt
 
 .. _columns-group-properties-elementBrowser:
 
-elementBrowser
-~~~~~~~~~~~~~~
+fieldControl => elementBrowser
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. include:: ../FieldControl/ElementBrowser.rst.txt
 
-insertClipboard
-~~~~~~~~~~~~~~~
+fieldControl => insertClipboard
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. include:: ../FieldControl/InsertClipboard.rst.txt
 
-listModule
-~~~~~~~~~~
+fieldControl => listModule
+~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. include:: ../FieldControl/ListModule.rst.txt
 
@@ -232,43 +238,49 @@ fieldWizard
 
 .. include:: ../Properties/CommonFieldWizard.rst.txt
 
-defaultLanguageDifferences
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+The following wizards are available for this type:
+
+.. contents::
+   :local:
+   :depth: 1
+
+fieldWizard => defaultLanguageDifferences
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. include:: ../FieldWizard/DefaultLanguageDifferences.rst.txt
 
-fileThumbnails
-~~~~~~~~~~~~~~
+fieldWizard => fileThumbnails
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. include:: ../FieldWizard/FileThumbnails.rst.txt
 
-fileTypeList
-~~~~~~~~~~~~
+fieldWizard => fileTypeList
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. include:: ../FieldWizard/FileTypeList.rst.txt
 
-fileUpload
-~~~~~~~~~~
+fieldWizard => fileUpload
+~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. include:: ../FieldWizard/FileUpload.rst.txt
 
-localizationStateSelector
-~~~~~~~~~~~~~~~~~~~~~~~~~
+fieldWizard => localizationStateSelector
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. include:: ../FieldWizard/LocalizationStateSelector.rst.txt
 
-recordsOverview
-~~~~~~~~~~~~~~~
+fieldWizard => recordsOverview
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. include:: ../FieldWizard/RecordsOverview.rst.txt
 
-tableList
-~~~~~~~~~
+fieldWizard => tableList
+~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. include:: ../FieldWizard/TableList.rst.txt
 
-otherLanguageContent
-~~~~~~~~~~~~~~~~~~~~
+fieldWizard => otherLanguageContent
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. include:: ../FieldWizard/OtherLanguageContent.rst.txt
 

--- a/Documentation/ColumnsConfig/Type/ImageManipulation.rst
+++ b/Documentation/ColumnsConfig/Type/ImageManipulation.rst
@@ -69,8 +69,8 @@ behaviour
 
 .. include:: ../Properties/CommonBehaviour.rst.txt
 
-allowLanguageSynchronization
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+behaviour => allowLanguageSynchronization
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. include:: ../Behaviour/CommonAllowLanguageSynchronization.rst.txt
 
@@ -102,18 +102,25 @@ fieldWizard
 
 .. include:: ../Properties/CommonFieldWizard.rst.txt
 
-defaultLanguageDifferences
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+The following fieldWizards are available for this type:
+
+.. contents::
+   :local:
+   :depth: 1
+
+
+fieldWizard => defaultLanguageDifferences
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. include:: ../FieldWizard/DefaultLanguageDifferences.rst.txt
 
-localizationStateSelector
-~~~~~~~~~~~~~~~~~~~~~~~~~
+fieldWizard  => localizationStateSelector
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. include:: ../FieldWizard/LocalizationStateSelector.rst.txt
 
-otherLanguageContent
-~~~~~~~~~~~~~~~~~~~~
+fieldWizard => otherLanguageContent
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. include:: ../FieldWizard/OtherLanguageContent.rst.txt
 

--- a/Documentation/ColumnsConfig/Type/Inline.rst
+++ b/Documentation/ColumnsConfig/Type/Inline.rst
@@ -388,8 +388,8 @@ behaviour
 
 .. include:: ../Properties/CommonBehaviour.rst.txt
 
-allowLanguageSynchronization
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+behaviour => allowLanguageSynchronization
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. include:: ../Behaviour/CommonAllowLanguageSynchronization.rst.txt
 

--- a/Documentation/ColumnsConfig/Type/Radio.rst
+++ b/Documentation/ColumnsConfig/Type/Radio.rst
@@ -63,8 +63,8 @@ behaviour
 
 .. include:: ../Properties/CommonBehaviour.rst.txt
 
-allowLanguageSynchronization
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+behaviour => allowLanguageSynchronization
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. include:: ../Behaviour/CommonAllowLanguageSynchronization.rst.txt
 
@@ -89,18 +89,25 @@ fieldWizard
 
 .. include:: ../Properties/CommonFieldWizard.rst.txt
 
-defaultLanguageDifferences
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+The following fieldWizards are available for this type:
+
+.. contents::
+   :local:
+   :depth: 1
+
+
+fieldWizard => defaultLanguageDifferences
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. include:: ../FieldWizard/DefaultLanguageDifferences.rst.txt
 
-localizationStateSelector
-~~~~~~~~~~~~~~~~~~~~~~~~~
+fieldWizard => localizationStateSelector
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. include:: ../FieldWizard/LocalizationStateSelector.rst.txt
 
-otherLanguageContent
-~~~~~~~~~~~~~~~~~~~~
+fieldWizard => otherLanguageContent
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. include:: ../FieldWizard/OtherLanguageContent.rst.txt
 

--- a/Documentation/ColumnsConfig/Type/checkDefault.rst
+++ b/Documentation/ColumnsConfig/Type/checkDefault.rst
@@ -186,8 +186,8 @@ behaviour
 
 .. include:: ../Properties/CommonBehaviour.rst.txt
 
-allowLanguageSynchronization
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+behaviour => allowLanguageSynchronization
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. include:: ../Behaviour/CommonAllowLanguageSynchronization.rst.txt
 
@@ -226,18 +226,24 @@ fieldWizard
 
 .. include:: ../Properties/CommonFieldWizard.rst.txt
 
-defaultLanguageDifferences
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+The following fieldWizards are available for this renderType:
+
+.. contents::
+   :local:
+   :depth: 1
+
+fieldWizard => defaultLanguageDifferences
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. include:: ../FieldWizard/DefaultLanguageDifferences.rst.txt
 
-localizationStateSelector
-~~~~~~~~~~~~~~~~~~~~~~~~~
+fieldWizard => localizationStateSelector
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. include:: ../FieldWizard/LocalizationStateSelector.rst.txt
 
-otherLanguageContent
-~~~~~~~~~~~~~~~~~~~~
+fieldWizard => otherLanguageContent
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. include:: ../FieldWizard/OtherLanguageContent.rst.txt
 

--- a/Documentation/ColumnsConfig/Type/checkboxLabeledToggle.rst
+++ b/Documentation/ColumnsConfig/Type/checkboxLabeledToggle.rst
@@ -90,8 +90,8 @@ behaviour
 
 .. include:: ../Properties/CommonBehaviour.rst.txt
 
-allowLanguageSynchronization
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+behaviour => allowLanguageSynchronization
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. include:: ../Behaviour/CommonAllowLanguageSynchronization.rst.txt
 
@@ -120,18 +120,24 @@ fieldWizard
 
 .. include:: ../Properties/CommonFieldWizard.rst.txt
 
-defaultLanguageDifferences
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+The following fieldWizards are available for this renderType:
+
+.. contents::
+   :local:
+   :depth: 1
+
+fieldWizard => defaultLanguageDifferences
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. include:: ../FieldWizard/DefaultLanguageDifferences.rst.txt
 
-localizationStateSelector
-~~~~~~~~~~~~~~~~~~~~~~~~~
+fieldWizard => localizationStateSelector
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. include:: ../FieldWizard/LocalizationStateSelector.rst.txt
 
-otherLanguageContent
-~~~~~~~~~~~~~~~~~~~~
+fieldWizard => otherLanguageContent
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. include:: ../FieldWizard/OtherLanguageContent.rst.txt
 

--- a/Documentation/ColumnsConfig/Type/checkboxToggle.rst
+++ b/Documentation/ColumnsConfig/Type/checkboxToggle.rst
@@ -89,8 +89,8 @@ behaviour
 
 .. include:: ../Properties/CommonBehaviour.rst.txt
 
-allowLanguageSynchronization
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+behaviour => allowLanguageSynchronization
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. include:: ../Behaviour/CommonAllowLanguageSynchronization.rst.txt
 
@@ -119,18 +119,25 @@ fieldWizard
 
 .. include:: ../Properties/CommonFieldWizard.rst.txt
 
-defaultLanguageDifferences
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+The following fieldWizards are available for this renderType:
+
+.. contents::
+   :local:
+   :depth: 1
+
+
+fieldWizard => defaultLanguageDifferences
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. include:: ../FieldWizard/DefaultLanguageDifferences.rst.txt
 
-localizationStateSelector
-~~~~~~~~~~~~~~~~~~~~~~~~~
+fieldWizard => localizationStateSelector
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. include:: ../FieldWizard/LocalizationStateSelector.rst.txt
 
-otherLanguageContent
-~~~~~~~~~~~~~~~~~~~~
+fieldWizard => otherLanguageContent
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. include:: ../FieldWizard/OtherLanguageContent.rst.txt
 

--- a/Documentation/ColumnsConfig/Type/inputColorPicker.rst
+++ b/Documentation/ColumnsConfig/Type/inputColorPicker.rst
@@ -51,8 +51,8 @@ behaviour
 
 .. include:: ../Properties/CommonBehaviour.rst.txt
 
-allowLanguageSynchronization
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+behaviour => allowLanguageSynchronization
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. include:: ../Behaviour/CommonAllowLanguageSynchronization.rst.txt
 
@@ -84,18 +84,24 @@ fieldWizard
 
 .. include:: ../Properties/CommonFieldWizard.rst.txt
 
-defaultLanguageDifferences
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+The following fieldWizards are available for this renderType:
+
+.. contents::
+   :local:
+   :depth: 1
+
+fieldWizard => defaultLanguageDifferences
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. include:: ../FieldWizard/DefaultLanguageDifferences.rst.txt
 
-localizationStateSelector
-~~~~~~~~~~~~~~~~~~~~~~~~~
+fieldWizard => localizationStateSelector
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. include:: ../FieldWizard/LocalizationStateSelector.rst.txt
 
-otherLanguageContent
-~~~~~~~~~~~~~~~~~~~~
+fieldWizard => otherLanguageContent
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. include:: ../FieldWizard/OtherLanguageContent.rst.txt
 

--- a/Documentation/ColumnsConfig/Type/inputDateTime.rst
+++ b/Documentation/ColumnsConfig/Type/inputDateTime.rst
@@ -47,8 +47,8 @@ behaviour
 
 .. include:: ../Properties/CommonBehaviour.rst.txt
 
-allowLanguageSynchronization
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+behaviour => allowLanguageSynchronization
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. include:: ../Behaviour/CommonAllowLanguageSynchronization.rst.txt
 
@@ -91,18 +91,25 @@ fieldWizard
 
 .. include:: ../Properties/CommonFieldWizard.rst.txt
 
-defaultLanguageDifferences
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+The following fieldWizards are available for this renderType:
+
+.. contents::
+   :local:
+   :depth: 1
+
+
+fieldWizard => defaultLanguageDifferences
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. include:: ../FieldWizard/DefaultLanguageDifferences.rst.txt
 
-localizationStateSelector
-~~~~~~~~~~~~~~~~~~~~~~~~~
+fieldWizard => localizationStateSelector
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. include:: ../FieldWizard/LocalizationStateSelector.rst.txt
 
-otherLanguageContent
-~~~~~~~~~~~~~~~~~~~~
+fieldWizard => otherLanguageContent
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. include:: ../FieldWizard/OtherLanguageContent.rst.txt
 

--- a/Documentation/ColumnsConfig/Type/inputDefault.rst
+++ b/Documentation/ColumnsConfig/Type/inputDefault.rst
@@ -179,20 +179,27 @@ fieldWizard
 
 .. include:: ../Properties/CommonFieldWizard.rst.txt
 
-defaultLanguageDifferences
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+The following fieldWizards are available for this renderType:
+
+.. contents::
+   :local:
+   :depth: 1
+
+
+fieldWizard => defaultLanguageDifferences
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. include:: ../FieldWizard/DefaultLanguageDifferences.rst.txt
 
 .. _columns-input-properties-fieldWizard-localizationStateSelector:
 
-localizationStateSelector
-~~~~~~~~~~~~~~~~~~~~~~~~~
+fieldWizard => localizationStateSelector
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. include:: ../FieldWizard/LocalizationStateSelector.rst.txt
 
-otherLanguageContent
-~~~~~~~~~~~~~~~~~~~~
+fieldWizard => otherLanguageContent
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. include:: ../FieldWizard/OtherLanguageContent.rst.txt
 

--- a/Documentation/ColumnsConfig/Type/inputLink.rst
+++ b/Documentation/ColumnsConfig/Type/inputLink.rst
@@ -50,8 +50,8 @@ behaviour
 
 .. include:: ../Properties/CommonBehaviour.rst.txt
 
-allowLanguageSynchronization
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+behaviour => allowLanguageSynchronization
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. include:: ../Behaviour/CommonAllowLanguageSynchronization.rst.txt
 
@@ -85,18 +85,24 @@ fieldWizard
 
 .. include:: ../Properties/CommonFieldWizard.rst.txt
 
-defaultLanguageDifferences
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+The following fieldWizards are available for this renderType:
+
+.. contents::
+   :local:
+   :depth: 1
+
+fieldWizard => defaultLanguageDifferences
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. include:: ../FieldWizard/DefaultLanguageDifferences.rst.txt
 
-localizationStateSelector
-~~~~~~~~~~~~~~~~~~~~~~~~~
+fieldWizard => localizationStateSelector
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. include:: ../FieldWizard/LocalizationStateSelector.rst.txt
 
-otherLanguageContent
-~~~~~~~~~~~~~~~~~~~~
+fieldWizard => otherLanguageContent
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. include:: ../FieldWizard/OtherLanguageContent.rst.txt
 

--- a/Documentation/ColumnsConfig/Type/inputRsaInput.rst
+++ b/Documentation/ColumnsConfig/Type/inputRsaInput.rst
@@ -59,8 +59,8 @@ behaviour
 
 .. include:: ../Properties/CommonBehaviour.rst.txt
 
-allowLanguageSynchronization
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+behaviour => allowLanguageSynchronization
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. include:: ../Behaviour/CommonAllowLanguageSynchronization.rst.txt
 
@@ -89,13 +89,19 @@ fieldWizard
 
 .. include:: ../Properties/CommonFieldWizard.rst.txt
 
-defaultLanguageDifferences
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+The following fieldWizards are available for this renderType:
+
+.. contents::
+   :local:
+   :depth: 1
+
+fieldWizard => defaultLanguageDifferences
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. include:: ../FieldWizard/DefaultLanguageDifferences.rst.txt
 
-otherLanguageContent
-~~~~~~~~~~~~~~~~~~~~
+fieldWizard => otherLanguageContent
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. include:: ../FieldWizard/OtherLanguageContent.rst.txt
 

--- a/Documentation/ColumnsConfig/Type/selectCheckBox.rst
+++ b/Documentation/ColumnsConfig/Type/selectCheckBox.rst
@@ -72,8 +72,8 @@ behaviour
 
 .. include:: ../Properties/CommonBehaviour.rst.txt
 
-allowLanguageSynchronization
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+behaviour => allowLanguageSynchronization
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. include:: ../Behaviour/CommonAllowLanguageSynchronization.rst.txt
 
@@ -107,18 +107,24 @@ fieldWizard
 
 .. include:: ../Properties/CommonFieldWizard.rst.txt
 
-defaultLanguageDifferences
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+The following fieldWizards are available for this renderType:
+
+.. contents::
+   :local:
+   :depth: 1
+
+fieldWizard => defaultLanguageDifferences
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. include:: ../FieldWizard/DefaultLanguageDifferences.rst.txt
 
-localizationStateSelector
-~~~~~~~~~~~~~~~~~~~~~~~~~
+fieldWizard => localizationStateSelector
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. include:: ../FieldWizard/LocalizationStateSelector.rst.txt
 
-otherLanguageContent
-~~~~~~~~~~~~~~~~~~~~
+fieldWizard => otherLanguageContent
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. include:: ../FieldWizard/OtherLanguageContent.rst.txt
 

--- a/Documentation/ColumnsConfig/Type/selectMultipleSideBySide.rst
+++ b/Documentation/ColumnsConfig/Type/selectMultipleSideBySide.rst
@@ -80,8 +80,8 @@ behaviour
 
 .. include:: ../Properties/CommonBehaviour.rst.txt
 
-allowLanguageSynchronization
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+behaviour => allowLanguageSynchronization
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. include:: ../Behaviour/CommonAllowLanguageSynchronization.rst.txt
 
@@ -135,18 +135,24 @@ fieldWizard
 
 .. include:: ../Properties/CommonFieldWizard.rst.txt
 
-defaultLanguageDifferences
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+The following fieldWizards are available for this renderType:
+
+.. contents::
+   :local:
+   :depth: 1
+
+fieldWizard => defaultLanguageDifferences
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. include:: ../FieldWizard/DefaultLanguageDifferences.rst.txt
 
-localizationStateSelector
-~~~~~~~~~~~~~~~~~~~~~~~~~
+fieldWizard => localizationStateSelector
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. include:: ../FieldWizard/LocalizationStateSelector.rst.txt
 
-otherLanguageContent
-~~~~~~~~~~~~~~~~~~~~
+fieldWizard => otherLanguageContent
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. include:: ../FieldWizard/OtherLanguageContent.rst.txt
 

--- a/Documentation/ColumnsConfig/Type/selectSingle.rst
+++ b/Documentation/ColumnsConfig/Type/selectSingle.rst
@@ -145,8 +145,8 @@ behaviour
 
 .. include:: ../Properties/CommonBehaviour.rst.txt
 
-allowLanguageSynchronization
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+behaviour => allowLanguageSynchronization
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. include:: ../Behaviour/CommonAllowLanguageSynchronization.rst.txt
 
@@ -192,18 +192,24 @@ fieldWizard
 
 .. include:: ../Properties/CommonFieldWizard.rst.txt
 
-defaultLanguageDifferences
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+The following fieldWizards are available for this renderType:
+
+.. contents::
+   :local:
+   :depth: 1
+
+fieldWizard => defaultLanguageDifferences
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. include:: ../FieldWizard/DefaultLanguageDifferences.rst.txt
 
-localizationStateSelector
-~~~~~~~~~~~~~~~~~~~~~~~~~
+fieldWizard => localizationStateSelector
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. include:: ../FieldWizard/LocalizationStateSelector.rst.txt
 
-otherLanguageContent
-~~~~~~~~~~~~~~~~~~~~
+fieldWizard => otherLanguageContent
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. include:: ../FieldWizard/OtherLanguageContent.rst.txt
 

--- a/Documentation/ColumnsConfig/Type/selectSingleBox.rst
+++ b/Documentation/ColumnsConfig/Type/selectSingleBox.rst
@@ -80,8 +80,8 @@ behaviour
 
 .. include:: ../Properties/CommonBehaviour.rst.txt
 
-allowLanguageSynchronization
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+behaviour => allowLanguageSynchronization
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. include:: ../Behaviour/CommonAllowLanguageSynchronization.rst.txt
 
@@ -112,8 +112,14 @@ fieldControl
 
 .. include:: ../Properties/CommonFieldControl.rst.txt
 
-resetSelection
-~~~~~~~~~~~~~~
+The following fieldControls are available for this renderType:
+
+.. contents::
+   :local:
+   :depth: 1
+
+fieldControl => resetSelection
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. include:: ../FieldControl/ResetSelection.rst.txt
 
@@ -127,18 +133,24 @@ fieldWizard
 
 .. include:: ../Properties/CommonFieldWizard.rst.txt
 
-defaultLanguageDifferences
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+The following fieldWizards are available for this renderType:
+
+.. contents::
+   :local:
+   :depth: 1
+
+fieldWizard => defaultLanguageDifferences
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. include:: ../FieldWizard/DefaultLanguageDifferences.rst.txt
 
-localizationStateSelector
-~~~~~~~~~~~~~~~~~~~~~~~~~
+fieldWizard => localizationStateSelector
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. include:: ../FieldWizard/LocalizationStateSelector.rst.txt
 
-otherLanguageContent
-~~~~~~~~~~~~~~~~~~~~
+fieldWizard => otherLanguageContent
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. include:: ../FieldWizard/OtherLanguageContent.rst.txt
 

--- a/Documentation/ColumnsConfig/Type/selectTree.rst
+++ b/Documentation/ColumnsConfig/Type/selectTree.rst
@@ -83,8 +83,8 @@ behaviour
 
 .. include:: ../Properties/CommonBehaviour.rst.txt
 
-allowLanguageSynchronization
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+behaviour => allowLanguageSynchronization
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. include:: ../Behaviour/CommonAllowLanguageSynchronization.rst.txt
 
@@ -118,8 +118,14 @@ fieldWizard
 
 .. include:: ../Properties/CommonFieldWizard.rst.txt
 
-localizationStateSelector
-~~~~~~~~~~~~~~~~~~~~~~~~~
+The following fieldWizards are available for this renderType:
+
+.. contents::
+   :local:
+   :depth: 1
+
+fieldWizard => localizationStateSelector
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. include:: ../FieldWizard/LocalizationStateSelector.rst.txt
 

--- a/Documentation/ColumnsConfig/Type/textDefault.rst
+++ b/Documentation/ColumnsConfig/Type/textDefault.rst
@@ -77,8 +77,8 @@ behaviour
 .. include:: ../Properties/CommonBehaviour.rst.txt
 
 
-allowLanguageSynchronization
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+behaviour => allowLanguageSynchronization
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. include:: ../Behaviour/CommonAllowLanguageSynchronization.rst.txt
 
@@ -138,18 +138,24 @@ fieldWizard
 
 .. include:: ../Properties/CommonFieldWizard.rst.txt
 
-defaultLanguageDifferences
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+The following fieldWizards are available for this renderType:
+
+.. contents::
+   :local:
+   :depth: 1
+
+fieldWizard => defaultLanguageDifferences
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. include:: ../FieldWizard/DefaultLanguageDifferences.rst.txt
 
-localizationStateSelector
-~~~~~~~~~~~~~~~~~~~~~~~~~
+fieldWizard => localizationStateSelector
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. include:: ../FieldWizard/LocalizationStateSelector.rst.txt
 
-otherLanguageContent
-~~~~~~~~~~~~~~~~~~~~
+fieldWizard => otherLanguageContent
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. include:: ../FieldWizard/OtherLanguageContent.rst.txt
 

--- a/Documentation/ColumnsConfig/Type/textT3editor.rst
+++ b/Documentation/ColumnsConfig/Type/textT3editor.rst
@@ -61,8 +61,8 @@ behaviour
 
 .. include:: ../Properties/CommonBehaviour.rst.txt
 
-allowLanguageSynchronization
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+behaviour => allowLanguageSynchronization
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. include:: ../Behaviour/CommonAllowLanguageSynchronization.rst.txt
 
@@ -86,18 +86,25 @@ fieldWizard
 
 .. include:: ../Properties/CommonFieldWizard.rst.txt
 
-defaultLanguageDifferences
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+The following fieldWizards are available for this renderType:
+
+.. contents::
+   :local:
+   :depth: 1
+
+
+fieldWizard => defaultLanguageDifferences
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. include:: ../FieldWizard/DefaultLanguageDifferences.rst.txt
 
-localizationStateSelector
-~~~~~~~~~~~~~~~~~~~~~~~~~
+fieldWizard => localizationStateSelector
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. include:: ../FieldWizard/LocalizationStateSelector.rst.txt
 
-otherLanguageContent
-~~~~~~~~~~~~~~~~~~~~
+fieldWizard => otherLanguageContent
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. include:: ../FieldWizard/OtherLanguageContent.rst.txt
 

--- a/Documentation/ColumnsConfig/Type/textTextTable.rst
+++ b/Documentation/ColumnsConfig/Type/textTextTable.rst
@@ -56,8 +56,8 @@ behaviour
 
 .. include:: ../Properties/CommonBehaviour.rst.txt
 
-allowLanguageSynchronization
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+behaviour => allowLanguageSynchronization
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. include:: ../Behaviour/CommonAllowLanguageSynchronization.rst.txt
 
@@ -96,18 +96,24 @@ fieldWizard
 
 .. include:: ../Properties/CommonFieldWizard.rst.txt
 
-defaultLanguageDifferences
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+The following fieldWizards are available for this renderType:
+
+.. contents::
+   :local:
+   :depth: 1
+
+fieldWizard => defaultLanguageDifferences
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. include:: ../FieldWizard/DefaultLanguageDifferences.rst.txt
 
-localizationStateSelector
-~~~~~~~~~~~~~~~~~~~~~~~~~
+fieldWizard => localizationStateSelector
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. include:: ../FieldWizard/LocalizationStateSelector.rst.txt
 
-otherLanguageContent
-~~~~~~~~~~~~~~~~~~~~
+fieldWizard => otherLanguageContent
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. include:: ../FieldWizard/OtherLanguageContent.rst.txt
 


### PR DESCRIPTION
This concerns properties that are not direct properties of
['columns']['config'] but are subproperties of one of the
listed properties.

For example:

* ['columns']['config']['behaviour']['allowLanguageSynchronization']
* ['columns']['config']['fieldWizard']['defaultLanguageDifferences']

Before everything was listed in one list, which made it easy to get
this mixed up.

Now,

- the subproperties have a title which includes the property
- each property with subproperties has a small table of contents
  listing the possible subproperties

Resolves: #296
Resolves: #260
Releases: master, 10.4, 9.5