### PR TITLE
Fix erroneous explanation in TCA Types and add more details

### DIFF
--- a/Documentation/Types/Index.rst
+++ b/Documentation/Types/Index.rst
@@ -61,7 +61,7 @@ Let's take the internal notes (sys\_note) as a basic example. The ['types'] sect
         ],
     ]
 
-It specifies two tabs: First one with four fields "general", "category" "subject" and "message", and second with the
+It specifies two tabs: First one with three fields "category" "subject" and "message", and second with the
 field "personal" on it. Only the default type "0" is specified. Opening such a record looks like this:
 
 .. figure:: ../Images/TypesSysNote.png

--- a/Documentation/Types/Index.rst
+++ b/Documentation/Types/Index.rst
@@ -61,8 +61,8 @@ Let's take the internal notes (sys\_note) as a basic example. The ['types'] sect
         ],
     ]
 
-It specifies two tabs: First one with three fields "category" "subject" and "message", and second with the
-field "personal" on it. Only the default type "0" is specified. Opening such a record looks like this:
+It specifies two tabs: the first one labelled "general" with three fields "category" "subject" and "message", and the second one labelled "access" with the
+field "personal". Only the default type "0" is specified. Opening such a record looks like this:
 
 .. figure:: ../Images/TypesSysNote.png
    :alt: The internal note input form


### PR DESCRIPTION
The explanation was listing the tab label as a field. Change it so the explanation explicitly define the tab labels and fixed the fields listing.