### PR TITLE
Use gmmktime to define date range

### DIFF
--- a/Documentation/ColumnsConfig/Properties/InputRange.rst.txt
+++ b/Documentation/ColumnsConfig/Properties/InputRange.rst.txt
@@ -35,6 +35,6 @@
     .. code-block:: php
 
         'range' => [
-            'upper' => mktime(0, 0, 0, 12, 31, 2020),
-            'lower' => mktime(0, 0, 0, 1, 1, 2014),
+            'upper' => gmmktime(23, 59, 59, 12, 31, 2020),
+            'lower' => gmmktime(0, 0, 0, 1, 1, 2014),
         ],


### PR DESCRIPTION
1. The value stored in the database will be in UTC. Thus the range values should also be defined in UTC.
2. `23, 59, 59, 12, 31, 2020` includes the whole day for `upper`