### PR TITLE
[TASK] Add Cross-Link to PageTypes

### DIFF
--- a/Documentation/Ctrl/CtrlTypeiconClasses.rst.txt
+++ b/Documentation/Ctrl/CtrlTypeiconClasses.rst.txt
@@ -10,7 +10,8 @@ typeicon\_classes
 :aspect:`Description`
     Array of names to use for the records. The keys must correspond to the values found in the column
     referenced in the :ref:`typeicon_column <ctrl-reference-typeicon-column>` property. The values correspond
-    to icons registered in the :ref:`Icon API <t3coreapi:icon>`.
+    to icons registered in the :ref:`Icon API <t3coreapi:icon>`. For using and configuring `typeicon_classes`
+    for custom page types, please see :ref:`Create a new Page Type<t3coreapi:page-types-example>`.
 
     **Example from the `tt_content` table:**
 


### PR DESCRIPTION
See Core Feature 90042
See https://github.com/TYPO3-Documentation/TYPO3CMS-Reference-CoreApi/issues/845

As in case of `pages` typeicon_classes needs to be extended to handle all cases, we should cross-link that documentation.
