### PR TITLE
[TASK] Replace `colorPicker` with `colorpicker`

### DIFF
--- a/Documentation/ColumnsConfig/Type/inputColorPicker.rst
+++ b/Documentation/ColumnsConfig/Type/inputColorPicker.rst
@@ -3,10 +3,10 @@
 .. _columns-input-renderType-colorpicker:
 
 ===================
-input (colorPicker)
+input (colorpicker)
 ===================
 
-This page describes the :ref:`input <columns-input>` type with renderType='colorPicker'.
+This page describes the :ref:`input <columns-input>` type with renderType='colorpicker'.
 
 An input field with a JavaScript color picker.
 


### PR DESCRIPTION
As used in the example the correct `renderType` is `colorpicker` (lowercase; no lowerCamelCase).