### PR TITLE
Remove false information about RealURl from Slug.rst

### DIFF
--- a/Documentation/ColumnsConfig/Type/Slug.rst
+++ b/Documentation/ColumnsConfig/Type/Slug.rst
@@ -23,7 +23,7 @@ With a URL like `https://www.typo3.org/ch/community/values/core-values/` a URL s
 Within TYPO3, a slug is always part of the URL "path" - it does not contain scheme, host, HTTP verb, etc.
 
 A slug is usually added to a TCA-based database table, containing some rules for evaluation and definition.
-Slugs can contain slashes.
+A slug is a segment of a URL, but it is not limited to be separated by slashes. Therefore, a slug can contain slashes.
 
 If a TCA table contains a field called "slug", it needs to be filled for every existing record. It can
 be shown and edited via regular Backend Forms, and is also evaluated during persistence via DataHandler.

--- a/Documentation/ColumnsConfig/Type/Slug.rst
+++ b/Documentation/ColumnsConfig/Type/Slug.rst
@@ -23,9 +23,7 @@ With a URL like `https://www.typo3.org/ch/community/values/core-values/` a URL s
 Within TYPO3, a slug is always part of the URL "path" - it does not contain scheme, host, HTTP verb, etc.
 
 A slug is usually added to a TCA-based database table, containing some rules for evaluation and definition.
-
-In contrast to concepts within RealURL of "URL segments", a slug is a segment of a URL, but it is not limited
-to be separated by slashes. Therefore, a slug can contain slashes.
+Slugs can contain slashes.
 
 If a TCA table contains a field called "slug", it needs to be filled for every existing record. It can
 be shown and edited via regular Backend Forms, and is also evaluated during persistence via DataHandler.


### PR DESCRIPTION
The statement about RealURL is incorrect: path segments there can contain slashes if the whole path is overwritten, just like slugs. Therefore the statement provides false information about RealURL and should be removed.