### PR TITLE
[BUGFIX] Fix case of mentioned defaultAsReadonly value

### DIFF
--- a/Documentation/Columns/ColumnsL10nMode.rst.txt
+++ b/Documentation/Columns/ColumnsL10nMode.rst.txt
@@ -23,7 +23,7 @@ l10n_mode
         field of the localized record. The DataHandler keeps the values of localized records in sync and actively copies
         a changed value from the default language record into the localized overlays if changed.
         You can force the field to be displayed as readonly (with default language value) 
-        by setting  :ref:`"l10n_display" <columns-properties-l10n-display>` to `defaultAsReadOnly`.
+        by setting  :ref:`"l10n_display" <columns-properties-l10n-display>` to `defaultAsReadonly`.
 
     prefixLangTitle
         The field value from the default language record gets copied when an localization overlay is created, but the


### PR DESCRIPTION
Documentation of l10n_mode mentions l10n_display setting with value 'defaultAsRead**O**nly'. The value of the setting is case sensitive and must be 'defaultAsRead**o**nly'.

This also affects 10.4 and 9.5 branches. Should I create separate Pull Requests for those or is there a merge strategy which allows to apply the patch to multiple branches?