### PR TITLE
[FEATURE] Improvements to start page

### DIFF
--- a/Documentation/Index.rst
+++ b/Documentation/Index.rst
@@ -14,14 +14,15 @@ A complete reference to the Table Configuration Array :php:`$GLOBALS['TCA']`.
       TYPO3 community (see :ref:`credits`)
 
 :License:
-      Open Publication License available from http://www.opencontent.org/openpub/
+      Open Publication License available from
+      http://www.opencontent.org/openpub/
 
 
 .. sidebar:: For contributors
 
-   * :ref:`How to contribute to documentation <h2document:contribute>`
-   * :ref:`Link targets <Link-targets>`
-   * Shortcut: `t3tca` is the usual alias for cross-referencing.
+   *  :ref:`How to contribute to documentation <h2document:contribute>`
+   *  :ref:`Link targets <Link-targets>`
+   *  Shortcut: `t3tca` is the usual alias for cross-referencing.
 
 The content of this document is related to TYPO3, a GNU/GPL CMS/Framework
 available from https://typo3.org/.
@@ -34,23 +35,23 @@ This document is included as part of the official TYPO3 documentation.
 
 **Core Manual**
 
-This document is a Core Manual. Core Manuals address the built in
-functionality of TYPO3 and are designed to provide the reader with in-
-depth information. Each Core Manual addresses a particular process or
-function and how it is implemented within the TYPO3 source code. These
-may include information on available APIs, specific configuration
-options, etc.
+This document is a Core Manual. Core Manuals address the built in functionality
+of TYPO3 and are designed to provide the reader with in- depth information.
+Each Core Manual addresses a particular process or function and how it is
+implemented within the TYPO3 source code. These may include information on
+available APIs, specific configuration options, etc.
 
-Core Manuals are written as reference manuals. The reader should rely
-on the :ref:`sitemap` to identify what particular section will best
-address the task at hand.
+Core Manuals are written as reference manuals. The reader should rely on the
+:ref:`sitemap` to identify what particular section will best address the task
+at hand.
 
 
 **Versions**
 
-TCA properties change between major versions, this main array had significant refactorings
-especially between core versions 6.2 to 7 LTS, and again between 7 LTS and 8 LTS. Use the version
-selector of this documentation to select the documentation variant that fits.
+TCA properties change between major versions, this main array had significant
+refactorings especially between core versions 6.2 to 7 LTS, and again between 7
+LTS and 8 LTS. Use the version selector of this documentation to select the
+documentation variant that fits.
 
 
 .. _credits:
@@ -60,7 +61,8 @@ selector of this documentation to select the documentation variant that fits.
 The original reference to the TCA was written by Kasper Skårhøj. Subsequent
 versions have been updated by François Suter. Several Core Team members and
 other contributors maintained this document over time, see the list of
-`contributors on GitHub <https://github.com/TYPO3-Documentation/TYPO3CMS-Reference-TCA/graphs/contributors>`__.
+`contributors on GitHub
+<https://github.com/TYPO3-Documentation/TYPO3CMS-Reference-TCA/graphs/contributors>`__.
 
 A big "Thank You!" goes to every single one of them.
 
@@ -70,10 +72,10 @@ A big "Thank You!" goes to every single one of them.
 For general questions about the documentation get in touch with the
 `Documentation Team <https://typo3.org/community/teams/documentation>`__.
 
-If you find a bug in this manual, please do not be afraid to suggest a fix, e.g.
-by using the :guilabel:`"Edit on GitHub"` button in the top right corner.
-Alternatively you can
-`file an issue <https://github.com/TYPO3-Documentation/TYPO3CMS-Reference-TCA/issues>`__.
+If you find a bug in this manual, please do not be afraid to suggest a fix,
+e.g. by using the :guilabel:`"Edit on GitHub"` button in the top right corner.
+Alternatively you can `file an issue
+<https://github.com/TYPO3-Documentation/TYPO3CMS-Reference-TCA/issues>`__.
 
 
 .. toctree::

--- a/Documentation/Index.rst
+++ b/Documentation/Index.rst
@@ -75,7 +75,7 @@ For general questions about the documentation get in touch with the
 `Documentation Team <https://typo3.org/community/teams/documentation>`__.
 
 If you find a bug in this manual, please do not be afraid to suggest a fix, e.g.
-by using the "Edit me on GitHub" button in the top right corner.
+by using the "Edit on GitHub" button in the top right corner.
 Alternatively you can
 `file an issue <https://github.com/TYPO3-Documentation/TYPO3CMS-Reference-TCA/issues>`__.
 

--- a/Documentation/Index.rst
+++ b/Documentation/Index.rst
@@ -74,7 +74,7 @@ A big "Thank You!" goes to every single one of them.
 For general questions about the documentation get in touch with the
 `Documentation Team <https://typo3.org/community/teams/documentation>`__.
 
-If you find a bug in this manual, please be so kind as to make a change, e.g.
+If you find a bug in this manual, please do not be afraid to suggest a fix, e.g.
 by using the "Edit me on GitHub" button in the top right corner.
 Alternatively you can just
 `file an issue <https://github.com/TYPO3-Documentation/TYPO3CMS-Reference-TCA/issues>`__.

--- a/Documentation/Index.rst
+++ b/Documentation/Index.rst
@@ -75,7 +75,7 @@ For general questions about the documentation get in touch with the
 `Documentation Team <https://typo3.org/community/teams/documentation>`__.
 
 If you find a bug in this manual, please do not be afraid to suggest a fix, e.g.
-by using the "Edit on GitHub" button in the top right corner.
+by using the :guilabel:`"Edit on GitHub"` button in the top right corner.
 Alternatively you can
 `file an issue <https://github.com/TYPO3-Documentation/TYPO3CMS-Reference-TCA/issues>`__.
 

--- a/Documentation/Index.rst
+++ b/Documentation/Index.rst
@@ -91,4 +91,4 @@ Alternatively you can just
     Palettes/Index
     Types/Index
     Sitemap
-    Targets
+    

--- a/Documentation/Index.rst
+++ b/Documentation/Index.rst
@@ -1,6 +1,4 @@
 .. include:: Includes.txt
-
-
 .. _start:
 
 =============
@@ -16,26 +14,23 @@ A complete reference to the Table Configuration Array :php:`$GLOBALS['TCA']`.
       TYPO3 community (see :ref:`credits`)
 
 :License:
-      Open Publication License available from `www.opencontent.org/openpub/
-      <http://www.opencontent.org/openpub/>`_
-
-.. rst-class:: horizbuttons-primary-xxl
-
--  :ref:`Sitemap`
+      Open Publication License available from http://www.opencontent.org/openpub/
 
 
 .. sidebar:: For contributors
 
    * :ref:`How to contribute to documentation <h2document:contribute>`
-   * :ref:`Link targets <Linktargets>` (for cross referencing)
+   * :ref:`Link targets <Link-targets>`
    * Shortcut: `t3tca` is the usual alias for cross-referencing.
 
 The content of this document is related to TYPO3, a GNU/GPL CMS/Framework
-available from `www.typo3.org <https://typo3.org/>`_
+available from https://typo3.org/.
+
 
 **Official documentation**
 
 This document is included as part of the official TYPO3 documentation.
+
 
 **Core Manual**
 
@@ -57,12 +52,13 @@ TCA properties change between major versions, this main array had significant re
 especially between core versions 6.2 to 7 LTS, and again between 7 LTS and 8 LTS. Use the version
 selector of this documentation to select the documentation variant that fits.
 
+
 .. _credits:
 
 **Credits**
 
 The original reference to the TCA was written by Kasper Skårhøj. Subsequent
-versions have been updated by François Suter. Several core team members and
+versions have been updated by François Suter. Several Core Team members and
 other contributors maintained this document over time, see the list of
 `contributors on GitHub <https://github.com/TYPO3-Documentation/TYPO3CMS-Reference-TCA/graphs/contributors>`__.
 

--- a/Documentation/Index.rst
+++ b/Documentation/Index.rst
@@ -7,36 +7,28 @@
 TCA Reference
 =============
 
-:Previous Key:
-      doc_core_tca
-
-:Version:
-      |release|
+A complete reference to the Table Configuration Array :php:`$GLOBALS['TCA']`.
 
 :Language:
       en
 
-:Description:
-      Complete reference to the Table Configuration Array :php:`$GLOBALS['TCA']`.
-
-:Keywords:
-      forAdmins, forDevelopers, forIntermediates
-
-:Copyright:
-      2000-2017
-
 :Author:
-      Documentation Team
-
-:Email:
-      documentation@typo3.org
+      TYPO3 community (see :ref:`credits`)
 
 :License:
       Open Publication License available from `www.opencontent.org/openpub/
       <http://www.opencontent.org/openpub/>`_
 
-:Rendered:
-      |today|
+.. rst-class:: horizbuttons-primary-xxl
+
+-  :ref:`Sitemap`
+
+
+.. sidebar:: For contributors
+
+   * :ref:`How to contribute to documentation <h2document:contribute>`
+   * :ref:`Link targets <Linktargets>` (for cross referencing)
+   * Shortcut: `t3tca` is the usual alias for cross-referencing.
 
 The content of this document is related to TYPO3, a GNU/GPL CMS/Framework
 available from `www.typo3.org <https://typo3.org/>`_
@@ -44,12 +36,6 @@ available from `www.typo3.org <https://typo3.org/>`_
 **Official documentation**
 
 This document is included as part of the official TYPO3 documentation.
-It has been approved by the TYPO3 Documentation Team following a peer-
-review process. The reader should expect the information in this
-document to be accurate - please report discrepancies to the
-Documentation Team (documentation@typo3.org). Official documents are
-kept up-to-date to the best of the Documentation Team's abilities.
-
 
 **Core Manual**
 
@@ -61,7 +47,7 @@ may include information on available APIs, specific configuration
 options, etc.
 
 Core Manuals are written as reference manuals. The reader should rely
-on the Table of Contents to identify what particular section will best
+on the :ref:`sitemap` to identify what particular section will best
 address the task at hand.
 
 
@@ -71,32 +57,27 @@ TCA properties change between major versions, this main array had significant re
 especially between core versions 6.2 to 7 LTS, and again between 7 LTS and 8 LTS. Use the version
 selector of this documentation to select the documentation variant that fits.
 
+.. _credits:
 
 **Credits**
 
-The original reference to the TCA was written by Kasper Skårhøj. This
-version has been updated by François Suter. Lots of core team members and
-other contributors maintain this document over time, see
-`github <https://github.com/TYPO3-Documentation/TYPO3CMS-Reference-CoreApi>`__ for
-an overview of recent contributors. A big "Thank You!" goes to every single one of them.
+The original reference to the TCA was written by Kasper Skårhøj. Subsequent
+versions have been updated by François Suter. Several core team members and
+other contributors maintained this document over time, see the list of
+`contributors on GitHub <https://github.com/TYPO3-Documentation/TYPO3CMS-Reference-TCA/graphs/contributors>`__.
+
+A big "Thank You!" goes to every single one of them.
 
 
-**Feedback**
+**Contribution**
 
-For general questions about the documentation get in touch by writing
-to `documentation@typo3.org <mailto:documentation@typo3.org>`_ .
+For general questions about the documentation get in touch with the
+`Documentation Team <https://typo3.org/community/teams/documentation>`__.
 
-If you find a bug in this manual, please be so kind as to check the
-`online version <https://docs.typo3.org/typo3cms/TCAReference/>`__.
-Use the "Edit me on GitHub" button in the top right corner
-and submit a pull request via GitHub. Alternatively you can just file an issue
-using the `bug tracker <https://github.com/TYPO3-Documentation/TYPO3CMS-Reference-TCA/issues>`__.
-
-Maintaining high quality documentation requires time and effort
-and the TYPO3 Documentation Team always appreciates support.
-If you want to support us, please join the `#typo3-documentation` channel
-on `typo3.slack.com <https://typo3.slack.com/>`__ to get in contact. If you're not
-using Slack yet, trigger a `Slack invite <https://forger.typo3.com/slack>`__.
+If you find a bug in this manual, please be so kind as to make a change, e.g.
+by using the "Edit me on GitHub" button in the top right corner.
+Alternatively you can just
+`file an issue <https://github.com/TYPO3-Documentation/TYPO3CMS-Reference-TCA/issues>`__.
 
 
 .. toctree::

--- a/Documentation/Index.rst
+++ b/Documentation/Index.rst
@@ -18,11 +18,11 @@ A complete reference to the Table Configuration Array :php:`$GLOBALS['TCA']`.
       http://www.opencontent.org/openpub/
 
 
-.. sidebar:: For contributors
+.. sidebar:: Contributors:
 
    *  :ref:`How to contribute to documentation <h2document:contribute>`
    *  :ref:`Link targets <Link-targets>`
-   *  Shortcut: `t3tca` is the usual alias for cross-referencing.
+   *  `t3tca` is usually used in cross-referencing.
 
 The content of this document is related to TYPO3, a GNU/GPL CMS/Framework
 available from https://typo3.org/.

--- a/Documentation/Index.rst
+++ b/Documentation/Index.rst
@@ -90,5 +90,6 @@ Alternatively you can
     Interface/Index
     Palettes/Index
     Types/Index
+    genindex
     Sitemap
     

--- a/Documentation/Index.rst
+++ b/Documentation/Index.rst
@@ -76,7 +76,7 @@ For general questions about the documentation get in touch with the
 
 If you find a bug in this manual, please do not be afraid to suggest a fix, e.g.
 by using the "Edit me on GitHub" button in the top right corner.
-Alternatively you can just
+Alternatively you can
 `file an issue <https://github.com/TYPO3-Documentation/TYPO3CMS-Reference-TCA/issues>`__.
 
 

--- a/Documentation/Settings.cfg
+++ b/Documentation/Settings.cfg
@@ -53,7 +53,8 @@ use_opensearch       = https://docs.typo3.org/m/typo3/reference-tca/master/en-us
 
 ; in this manual we actually use:
 
-t3core        = https://docs.typo3.org/c/typo3/cms-core/master/en-us/
+h2document = https://docs.typo3.org/m/typo3/docs-how-to-document/master/en-us/
+t3core     = https://docs.typo3.org/c/typo3/cms-core/master/en-us/
 t3coreapi  = https://docs.typo3.org/m/typo3/reference-coreapi/master/en-us/
 t3fal      = https://docs.typo3.org/m/typo3/reference-fal/master/en-us/
 t3l10n     = https://docs.typo3.org/m/typo3/guide-frontendlocalization/master/en-us/

--- a/Documentation/Targets.rst
+++ b/Documentation/Targets.rst
@@ -1,11 +1,12 @@
-.. include:: Includes.txt
+:orphan:
 
-.. _targets-for-crossreferencing:
-.. _labels-for-crossreferencing:
-.. _Linktargets:
+.. include:: /Includes.txt
+.. index:: 
+   Link targets
+   see: Targets; Link targets
+.. _Link-Targets:
 
 Link Targets
 ============
 
 .. ref-targets-list::
-

--- a/Documentation/genindex.rst
+++ b/Documentation/genindex.rst
@@ -1,0 +1,11 @@
+.. include:: /Includes.txt
+
+.. _Index:
+
+=====
+Index
+=====
+
+.. About adding an index:
+..    https://stackoverflow.com/questions/25243482/how-to-add-sphinx-generated-index-to-the-sidebar-when-using-read-the-docs-theme
+..    https://stackoverflow.com/questions/36235578/how-can-i-include-the-genindex-in-a-sphinx-toc


### PR DESCRIPTION
- Add link targets to start page and remove from main menu (as decided
  on Slack)
- remove "Previous key" (as decided on Slack)
- Remove some information from start page that is already displayed via
  the theme, e.g. in the footer, specifically: version, copyright, email
  etc.
- Add a link to the sitemap
- Update the texts (e.g. upon finding a bug, the preferred behaviour is
  NOT to send an email).