### PR TITLE
[TASK] Ask information about change in location Extending TCA (7.6)

### DIFF
--- a/Documentation/ExtendingTca/Examples/Index.rst
+++ b/Documentation/ExtendingTca/Examples/Index.rst
@@ -6,6 +6,14 @@
 Customization examples
 ^^^^^^^^^^^^^^^^^^^^^^
 
+.. note::
+
+   This page is for an outdated TYPO3 version (7.6). For newer versions, you
+   can find the information in:
+
+   *  TYPO3 Explained: :ref:`t3coreapi:extending-tca` (7.6)
+
+
 Many extracts can be found throughout the manual, but this section
 provides more complete examples.
 

--- a/Documentation/ExtendingTca/Index.rst
+++ b/Documentation/ExtendingTca/Index.rst
@@ -6,6 +6,14 @@
 Extending the $TCA array
 ------------------------
 
+.. note::
+
+   This page is for an outdated TYPO3 version (7.6). For newer versions, you
+   can find the information in:
+
+   *  TYPO3 Explained: :ref:`t3coreapi:extending-tca` (7.6)
+
+
 Being a PHP array, the Table Configuration Array can be easily
 extended. It can be accessed as the global variable :code:`$GLOBALS['TCA']`.
 TYPO3 also provides APIs for making this simpler.

--- a/Documentation/ExtendingTca/StoringChanges/Index.rst
+++ b/Documentation/ExtendingTca/StoringChanges/Index.rst
@@ -6,6 +6,14 @@
 Storing the changes
 ===================
 
+.. note::
+
+   This page is for an outdated TYPO3 version (7.6). For newer versions, you
+   can find the information in:
+
+   *  TYPO3 Explained: :ref:`t3coreapi:extending-tca` (7.6)
+
+
 There are various ways to store changes to :php:`$GLOBALS['TCA']`. They
 depend - partly - on what you are trying to achieve and - a lot -
 on the version of TYPO3 CMS which you are targeting.

--- a/Documentation/ExtendingTca/Verifying/Index.rst
+++ b/Documentation/ExtendingTca/Verifying/Index.rst
@@ -6,6 +6,13 @@
 Verifying the $TCA
 ^^^^^^^^^^^^^^^^^^
 
+.. note::
+
+   This page is for an outdated TYPO3 version (7.6). For newer versions, you
+   can find the information in:
+
+   *  TYPO3 Explained: :ref:`t3coreapi:extending-tca` (7.6)
+
 You may find it necessary – at some point – to verify the full
 structure of the :code:`$TCA` in your TYPO3 installation. The System >
 Configuration module makes it possible to have an overview of the


### PR DESCRIPTION
"Extending TCA" was moved to "TYPO3 Explained" since version 8.7.
The outdated pages in TCA reference are still often listed as top results
for search.

This is a fix for directing users to the newer information.

Depends on: TYPO3-Documentation/TYPO3CMS-Reference-CoreApi#1371

Releases: 7.6