### PR TITLE
[BUGFIX] Replace semicolon by comma

### DIFF
--- a/Documentation/Columns/Properties/DisplayCond.rst
+++ b/Documentation/Columns/Properties/DisplayCond.rst
@@ -141,7 +141,7 @@ headline "Example" defined::
             'FIELD:header:=:Example'
          ]
       ]
-   ];
+   ],
 
 
 A complex example in a flexform


### PR DESCRIPTION
The PHP example code in "A complex example" is part of an array declaration, so it must not end with a `;` but with a `,`