### PR TITLE
[BUGFIX] Fix inverted description

### DIFF
--- a/Documentation/ColumnsConfig/CommonProperties/LocalizeReferencesAtParentLocalization.rst
+++ b/Documentation/ColumnsConfig/CommonProperties/LocalizeReferencesAtParentLocalization.rst
@@ -13,4 +13,5 @@ localizeReferencesAtParentLocalization
 
    Defines whether referenced records should be localized when the current
    record gets localized. This does only apply if references are **not** stored using
-   `MM` tables.
+   `MM` tables. In addition, when using the type `group`, :ref:`foreign_table <columns-group-properties-foreign-table>`
+   has to reference the same table as in :ref:`allowed <columns-group-properties-allowed>`.

--- a/Documentation/ColumnsConfig/CommonProperties/LocalizeReferencesAtParentLocalization.rst
+++ b/Documentation/ColumnsConfig/CommonProperties/LocalizeReferencesAtParentLocalization.rst
@@ -12,6 +12,6 @@ localizeReferencesAtParentLocalization
    :Types: :ref:`group <columns-group>`, :ref:`select <columns-select>`
 
    Defines whether referenced records should be localized when the current
-   record gets localized. This does only apply if references are **not** stored using
+   record gets localized. This only applies if references are **not** stored using
    `MM` tables. In addition, when using the type `group`, :ref:`foreign_table <columns-group-properties-foreign-table>`
-   has to reference the same table as in :ref:`allowed <columns-group-properties-allowed>`.
+   has to reference the same table in :ref:`allowed <columns-group-properties-allowed>`.

--- a/Documentation/ColumnsConfig/CommonProperties/LocalizeReferencesAtParentLocalization.rst
+++ b/Documentation/ColumnsConfig/CommonProperties/LocalizeReferencesAtParentLocalization.rst
@@ -9,8 +9,8 @@ localizeReferencesAtParentLocalization
 
    :type: boolean
    :Scope: Proc.
-   :Types: :ref:`group <columns-group>`
+   :Types: :ref:`group <columns-group>`, :ref:`select <columns-select>`
 
    Defines whether referenced records should be localized when the current
-   record gets localized. This does only apply if references are stored using
+   record gets localized. This does only apply if references are **not** stored using
    `MM` tables.


### PR DESCRIPTION
The TCA option localizeReferencesAtParentLocalization only works if
the field is NOT stored in a MM table.

Also add the select field as a possible type, as it works with all
fields defining foreign_table.