### PR TITLE
Remove fullScreenRichtext configuration for TCA type text

### DIFF
--- a/Documentation/CodeSnippets/Rte1.rst.txt
+++ b/Documentation/CodeSnippets/Rte1.rst.txt
@@ -10,11 +10,6 @@
            'config' => [
                'type' => 'text',
                'enableRichtext' => true,
-               'fieldControl' => [
-                   'fullScreenRichtext' => [
-                       'disabled' => false,
-                   ],
-               ],
            ],
        ],
    ]


### PR DESCRIPTION
Removed `fullScreenRichtext` configuration from the example, as this most likely has never been supported by CKEditor in TYPO3.