### PR TITLE
Correct type declaration

### DIFF
--- a/Documentation/Ctrl/Properties/FormattedLabelUserFuncOptions.rst
+++ b/Documentation/Ctrl/Properties/FormattedLabelUserFuncOptions.rst
@@ -7,7 +7,7 @@ formattedLabel\_userFunc\_options
 
 .. confval:: formattedLabel_userFunc_options
 
-   :type: string
+   :type: array
    :Scope: Display
 
 


### PR DESCRIPTION
This is an array property, not a string.

Releases: master, 11.5