### PR TITLE
Type correction

### DIFF
--- a/Documentation/Ctrl/Properties/LabelUserfunc.rst
+++ b/Documentation/Ctrl/Properties/LabelUserfunc.rst
@@ -59,7 +59,7 @@ label\_userFunc\_options
 
 .. confval:: label_userFunc_options
 
-   :type: string
+   :type: array
    :Scope: Display
 
 


### PR DESCRIPTION
`label_userFunc_options` is an array, not a string, according to its own description. 

Releases: master, 11.5