### PR TITLE
[TASK] Remove mentions of empty check items value

### DIFF
--- a/Documentation/ColumnsConfig/Type/Check/Properties/Items.rst
+++ b/Documentation/ColumnsConfig/Type/Check/Properties/Items.rst
@@ -17,8 +17,8 @@ items
       in the integer value which ultimately goes into the database.
 
    In this array each entry is itself an array where the first entry (index 0) is the label (string or LLL reference).
-   The value sent to the database will be an integer where each bit represents the
-   state of a checkbox in this array.
+   The value sent to the database will be an integer representing a bit mask based on the position of the checkbox
+   in this array.
 
    A basic item looks like this:
 

--- a/Documentation/ColumnsConfig/Type/Check/Properties/Items.rst
+++ b/Documentation/ColumnsConfig/Type/Check/Properties/Items.rst
@@ -16,8 +16,8 @@ items
       You can have a maximum of 31 checkboxes in such an array and each element is represented by a single bit
       in the integer value which ultimately goes into the database.
 
-   In this array each entry is itself an array where the first entry is the label (string or LLL reference) and the
-   second entry is a blank value. The value sent to the database will be an integer where each bit represents the
+   In this array each entry is itself an array where the first entry (index 0) is the label (string or LLL reference).
+   The value sent to the database will be an integer where each bit represents the
    state of a checkbox in this array.
 
    A basic item looks like this:
@@ -25,8 +25,8 @@ items
    .. code-block:: php
 
       'items' => [
-         ['Green tomatoes', ''], // Note these should be LLL references
-         ['Red peppers', ''],
+         ['Green tomatoes'], // Note these should be LLL references
+         ['Red peppers'],
       ],
 
    Further properties can be set per item, but not all of them apply to all renderTypes:


### PR DESCRIPTION
The second entry is not needed for checkboxes.
This has been already simplified in core.
See: https://review.typo3.org/c/Packages/TYPO3.CMS/+/72056
And styleguide:
https://github.com/TYPO3/styleguide/pull/243