### PR TITLE
changes

### DIFF
--- a/Documentation/ColumnsConfig/Type/Category/Index.rst
+++ b/Documentation/ColumnsConfig/Type/Category/Index.rst
@@ -16,7 +16,7 @@ Category
 While using the type :php:`category`, TYPO3 takes care of generating the
 necessary TCA configuration.
 Developers only have to define the TCA column and add :php:`category` as the
-desired TCA type.
+desired TCA type in the tables's TCA file (inside or outside of the Overrides folder).
 
 .. include:: /CodeSnippets/Manual/CategorySimple.rst.txt
 

--- a/Documentation/ColumnsConfig/Type/Category/Index.rst
+++ b/Documentation/ColumnsConfig/Type/Category/Index.rst
@@ -14,7 +14,7 @@ Category
    creating a "TCA overrides" file.
 
 While using the type :php:`category`, TYPO3 takes care of generating the
-necessary TCA configuration and also of adding the database column.
+necessary TCA configuration.
 Developers only have to define the TCA column and add :php:`category` as the
 desired TCA type.
 

--- a/Documentation/ColumnsConfig/Type/Category/Index.rst
+++ b/Documentation/ColumnsConfig/Type/Category/Index.rst
@@ -10,13 +10,13 @@ Category
    The TCA field type called `category` has been added to TYPO3 Core. Its main
    purpose is to simplify the TCA configuration when adding a category
    tree to a record. It therefore supersedes the :php:`CategoryRegistry` as well
-   as the :php:`ExtensionManagementUtility->makeCategorizable()`, which required
+   as the :php:`ExtensionManagementUtility->makeCategorizable()`, which has required
    creating a "TCA overrides" file.
 
 While using the type :php:`category`, TYPO3 takes care of generating the
-necessary TCA configuration and also adds the database column automatically.
-Developers only have to configure the TCA column and add it to the
-desired record types.
+necessary TCA configuration and also of adding the database column.
+Developers only have to define the TCA column and add :php:`category` as the
+desired TCA type.
 
 .. include:: /CodeSnippets/Manual/CategorySimple.rst.txt
 
@@ -34,7 +34,7 @@ The following options can be overridden via :ref:`page TSconfig, TCE form
 
    It is still possible to configure a category tree with `type=select`
    and `renderType=selectTree`. This configuration will still work, but
-   could in most cases be simplified, using the new :php:`category` TCA type.
+   it can in most cases be simplified by using the new :php:`category` TCA type.
 
 
 .. toctree::


### PR DESCRIPTION
Question:
Is the Overrides folder required for "category"? 
Which field is added by TYPO3 to the database?

https://docs.typo3.org/c/typo3/cms-core/master/en-us/Changelog/8.5/Breaking-78384-FrontendIgnoresTCAInExtTables.html#migration