### PR TITLE
[TASK] Remove leftovers of internal_type as required

### DIFF
--- a/Documentation/ColumnsConfig/Type/Group/Index.rst
+++ b/Documentation/ColumnsConfig/Type/Group/Index.rst
@@ -17,9 +17,10 @@ This type is very flexible in its display options with all its different
 :ref:`fieldControl <columns-group-properties-fieldControl>` and
 :ref:`fieldWizard <columns-group-properties-fieldWizard>` options. A lot of them are available by default, however they must be enabled: :php:`disabled' => 'false'`
 
-It is required to set :ref:`internal_type <columns-group-properties-internal-type>`. Most common usage is to model
-database relations (n:1 or n:m) with `internal_type='db'`.
-In this case property :ref:`allowed <columns-group-properties-allowed>` is required.
+Most common usage is to model database relations (n:1 or n:m) with
+:ref:`internal_type='db' <columns-group-properties-internal-type>` (default).
+In this case property :ref:`allowed <columns-group-properties-allowed>` is
+required.
 
 The group field uses either the CSV format to store uids of related records or an intermediate mm table
 (in this case :ref:`MM <columns-group-properties-mm>` property is required).

--- a/Documentation/ColumnsConfig/Type/Group/Properties/InternalType.rst
+++ b/Documentation/ColumnsConfig/Type/Group/Properties/InternalType.rst
@@ -7,9 +7,9 @@ internal\_type
 
 .. confval:: internal_type
 
-   :Required: true
+   :Required: false
    :type: string
-   :Scope: Display  / Proc.
+   :Scope: Display / Proc.
    :Default: db
 
    Configures the internal type of the group type of the element.
@@ -19,10 +19,8 @@ internal\_type
       This will create a field where folders can be attached to the record.
 
    db
-      This will create a field where database records can be attached 
-      as references. As it is the default it can be ommitted.
-
-   There is no default value, the property is required.
+      This will create a field where database records can be attached
+      as references. As it is the default it can be omitted.
 
 .. deprecated:: 9.5
    The internal types `file` and `file_reference` have been deprecated with


### PR DESCRIPTION
Not everything has been cleaned up in commit eea5007.
This removes the leftover places, where internal_type
is mentioned as required.