### PR TITLE
[TASK] Remove elementBrowserAllowed from type inline

### DIFF
--- a/Documentation/ColumnsConfig/Type/Group/Properties/Appearance.rst
+++ b/Documentation/ColumnsConfig/Type/Group/Properties/Appearance.rst
@@ -12,21 +12,23 @@ appearance
    :InternalType: all
 
    Options for refining the appearance of group-type fields. This property is
-   automatically used for :ref:`FAL<t3fal:start>` relations created by the function
-   :php:`ExtensionManagementUtility::getFileFieldTCAConfig`.
+   automatically used for :ref:`FAL <t3coreapi:fal>` relations created by the
+   function :php:`ExtensionManagementUtility::getFileFieldTCAConfig`.
 
    elementBrowserType (string)
-      Allows set an alternative element browser type ("db" or "file") than
-      would otherwise be rendered based on the "internal_type" setting.
-      This is used internally for :ref:`FAL<t3fal:start>` file fields, where
-      internal_type is "db" but the element browser should be the file element
+      Allows to set an alternative element browser type (`db` or `file`) that
+      would otherwise be rendered based on the :ref:`internal_type <columns-group-properties-internal-type>` setting.
+      This is used internally for :ref:`FAL <t3coreapi:fal>` file fields, where
+      internal_type is `db` but the element browser should be the file element
       browser anyway.
 
    elementBrowserAllowed (string)
       Makes it possible to set an alternative element browser allowed string
-      than would otherwise be taken from the "allowed" setting of this field.
-      This is used internally for :ref:`FAL<t3fal:start>` file fields, where
-      this is used to supply the comma list of allowed file types.
+      that would otherwise be taken from the :ref:`allowed <columns-group-properties-allowed>` setting of this field.
+      This is used internally for :ref:`FAL <t3coreapi:fal>` file fields, where
+      this is used to supply the comma list of allowed file types. This also
+      affects whether the "Add media by URL" button is shown if online media
+      file extensions (e.g. `youtube` or `vimeo`) are included.
 
 Examples
 ========

--- a/Documentation/ColumnsConfig/Type/Inline/Properties/Appearance.rst
+++ b/Documentation/ColumnsConfig/Type/Inline/Properties/Appearance.rst
@@ -97,8 +97,3 @@ appearance
 
    elementBrowserEnabled (boolean)
       Hides or displays the element browser button in inline records
-
-   elementBrowserAllowed (string)
-      Sets the list of allowed element types, e.g. file extensions for file fields. For file fields this also affects
-      whether the "Add media by URL" button is shown if online media file extensions (e.g. `youtube` or `vimeo`) are
-      included.


### PR DESCRIPTION
The option elementBrowserAllowed was designed for group fields
to override the allowed extension list. It has no effect if used
directly on inline fields.

The further explanation about the "Add media by URL" button is
moved to the group field.

Also fix some typos and links while at it.