### PR TITLE
[BUGFIX] Remove unavailable pid option in linkPopup

### DIFF
--- a/Documentation/ColumnsConfig/Type/Input/Properties/LinkPopup.rst
+++ b/Documentation/ColumnsConfig/Type/Input/Properties/LinkPopup.rst
@@ -18,16 +18,6 @@ linkPopup
 
    **Options:**
 
-   pid (string)
-      pid of the new record. Can be a hard pid setting, or one of these markers, see
-      :ref:`select foreign_table_where <columns-select-properties-foreign-table-where>`.
-      Falls back to "current pid" if not set, forces pid=0 if records of this table are only
-      allowed on root level.
-
-      - :code:`###CURRENT_PID###`
-      - :code:`###THIS_UID###`
-      - :code:`###SITEROOT###`
-
    allowedExtensions (string, list)
       Comma separated list of allowed file extensions. By default, all extensions are allowed.
 


### PR DESCRIPTION
The pid setting does only work for controls like AddRecord or similar.
Links do not create a new record and hence do not need a target pid.
This is very likely a copy/paste error from back then.

Releases: main, 11.5, 10.4