### PR TITLE
[BUGFIX] Rename old configuration keys of fileFolderConfig

### DIFF
--- a/Documentation/ColumnsConfig/Type/Select/CheckBox/Properties.rst
+++ b/Documentation/ColumnsConfig/Type/Select/CheckBox/Properties.rst
@@ -12,12 +12,14 @@ Select properties
 *  :ref:`authmode <columns-select-properties-authmode>`
 *  :ref:`authmode > enforce <columns-select-properties-authmode-enforce>`
 *  :ref:`default <columns-select-properties-default>`
-*  :ref:`disableNoMatchingValueElement
-   <columns-select-properties-disableNoMatchingValueElement>`
+*  :ref:`disableNoMatchingValueElement <columns-select-properties-disableNoMatchingValueElement>`
 *  :ref:`exclusivekeys <columns-select-properties-exclusivekeys>`
-*  :ref:`filefolder <columns-select-properties-filefolder>`
-*  :ref:`filefolder_extlist <columns-select-properties-filefolder-extlist>`
-*  :ref:`filefolder_recursions <columns-select-properties-filefolder-recursions>`
+*  :ref:`fileFolderConfig <columns-select-properties-fileFolderConfig>`
+
+   *  :ref:`folder <columns-select-properties-fileFolderConfig.folder>`
+   *  :ref:`allowedExtensions <columns-select-properties-fileFolderConfig-allowedExtensions>`
+   *  :ref:`depth <columns-select-properties-fileFolderConfig-depth>`
+
 *  :ref:`foreign_table <columns-select-properties-foreign-table>`
 *  :ref:`foreign_table_prefix <columns-select-properties-foreign-table-prefix>`
 *  :ref:`foreign_table_where <columns-select-properties-foreign-table-where>`

--- a/Documentation/ColumnsConfig/Type/Select/MultipleSideBySide/Properties.rst
+++ b/Documentation/ColumnsConfig/Type/Select/MultipleSideBySide/Properties.rst
@@ -13,9 +13,12 @@ Select properties
 *  :ref:`default <columns-select-properties-default>`
 *  :ref:`disableNoMatchingValueElement <columns-select-properties-disableNoMatchingValueElement>`
 *  :ref:`exclusivekeys <columns-select-properties-exclusivekeys>`
-*  :ref:`filefolder <columns-select-properties-filefolder>`
-*  :ref:`filefolder_extlist <columns-select-properties-filefolder-extlist>`
-*  :ref:`filefolder_recursions <columns-select-properties-filefolder-recursions>`
+*  :ref:`fileFolderConfig <columns-select-properties-fileFolderConfig>`
+
+   *  :ref:`folder <columns-select-properties-fileFolderConfig.folder>`
+   *  :ref:`allowedExtensions <columns-select-properties-fileFolderConfig-allowedExtensions>`
+   *  :ref:`depth <columns-select-properties-fileFolderConfig-depth>`
+
 *  :ref:`foreign_table <columns-select-properties-foreign-table>`
 *  :ref:`foreign_table_prefix <columns-select-properties-foreign-table-prefix>`
 *  :ref:`foreign_table_where <columns-select-properties-foreign-table-where>`

--- a/Documentation/ColumnsConfig/Type/Select/Properties/FileFolderConfig.rst
+++ b/Documentation/ColumnsConfig/Type/Select/Properties/FileFolderConfig.rst
@@ -12,7 +12,7 @@ fileFolderConfig
 .. confval:: fileFolderConfig.folder
 
    :type: string
-   :Scope: Display  / Proc.
+   :Scope: Display / Proc.
    :RenderType: all
 
    Specifying a folder from where files are added to the item array.
@@ -22,9 +22,9 @@ fileFolderConfig
    prefix "EXT:" to point to an extension folder.
 
    Files from the folder is selected recursively to the level specified by
-   :ref:`fileFolder_recursions <columns-select-properties-filefolder-recursions>`
+   :ref:`fileFolderConfig.depth <columns-select-properties-fileFolderConfig-depth>`
    and only files of the extension defined by
-   :ref:`fileFolder_extList <columns-select-properties-filefolder-extlist>`
+   :ref:`fileFolderConfig.allowedExtensions <columns-select-properties-fileFolderConfig-allowedExtensions>`
    are selected.
 
    Only the file reference relative to the "fileFolderConfig.folder" is stored.

--- a/Documentation/ColumnsConfig/Type/Select/Single/Properties.rst
+++ b/Documentation/ColumnsConfig/Type/Select/Single/Properties.rst
@@ -39,9 +39,12 @@ Select properties
 *  :ref:`default <columns-select-properties-default>`
 *  :ref:`disableNoMatchingValueElement <columns-select-properties-disableNoMatchingValueElement>`
 *  :ref:`exclusivekeys <columns-select-properties-exclusivekeys>`
-*  :ref:`filefolder <columns-select-properties-filefolder>`
-*  :ref:`filefolder_extlist <columns-select-properties-filefolder-extlist>`
-*  :ref:`filefolder_recursions <columns-select-properties-filefolder-recursions>`
+*  :ref:`fileFolderConfig <columns-select-properties-fileFolderConfig>`
+
+   *  :ref:`folder <columns-select-properties-fileFolderConfig.folder>`
+   *  :ref:`allowedExtensions <columns-select-properties-fileFolderConfig-allowedExtensions>`
+   *  :ref:`depth <columns-select-properties-fileFolderConfig-depth>`
+
 *  :ref:`foreign_table <columns-select-properties-foreign-table>`
 *  :ref:`foreign_table_prefix <columns-select-properties-foreign-table-prefix>`
 *  :ref:`foreign_table_where <columns-select-properties-foreign-table-where>`

--- a/Documentation/ColumnsConfig/Type/Select/SingleBox/Properties.rst
+++ b/Documentation/ColumnsConfig/Type/Select/SingleBox/Properties.rst
@@ -13,9 +13,12 @@ Select properties
 *  :ref:`default <columns-select-properties-default>`
 *  :ref:`disableNoMatchingValueElement <columns-select-properties-disableNoMatchingValueElement>`
 *  :ref:`exclusivekeys <columns-select-properties-exclusivekeys>`
-*  :ref:`filefolder <columns-select-properties-filefolder>`
-*  :ref:`filefolder_extlist <columns-select-properties-filefolder-extlist>`
-*  :ref:`filefolder_recursions <columns-select-properties-filefolder-recursions>`
+*  :ref:`fileFolderConfig <columns-select-properties-fileFolderConfig>`
+
+   *  :ref:`folder <columns-select-properties-fileFolderConfig.folder>`
+   *  :ref:`allowedExtensions <columns-select-properties-fileFolderConfig-allowedExtensions>`
+   *  :ref:`depth <columns-select-properties-fileFolderConfig-depth>`
+
 *  :ref:`foreign_table <columns-select-properties-foreign-table>`
 *  :ref:`foreign_table_prefix <columns-select-properties-foreign-table-prefix>`
 *  :ref:`foreign_table_where <columns-select-properties-foreign-table-where>`

--- a/Documentation/ColumnsConfig/Type/Select/Tree/Properties.rst
+++ b/Documentation/ColumnsConfig/Type/Select/Tree/Properties.rst
@@ -13,9 +13,12 @@ Select properties
 *  :ref:`default <columns-select-properties-default>`
 *  :ref:`disableNoMatchingValueElement <columns-select-properties-disableNoMatchingValueElement>`
 *  :ref:`exclusivekeys <columns-select-properties-exclusivekeys>`
-*  :ref:`filefolder <columns-select-properties-filefolder>`
-*  :ref:`filefolder_extlist <columns-select-properties-filefolder-extlist>`
-*  :ref:`filefolder_recursions <columns-select-properties-filefolder-recursions>`
+*  :ref:`fileFolderConfig <columns-select-properties-fileFolderConfig>`
+
+   *  :ref:`folder <columns-select-properties-fileFolderConfig.folder>`
+   *  :ref:`allowedExtensions <columns-select-properties-fileFolderConfig-allowedExtensions>`
+   *  :ref:`depth <columns-select-properties-fileFolderConfig-depth>`
+
 *  :ref:`foreign_table <columns-select-properties-foreign-table>`
 *  :ref:`foreign_table_prefix <columns-select-properties-foreign-table-prefix>`
 *  :ref:`foreign_table_where <columns-select-properties-foreign-table-where>`


### PR DESCRIPTION
fileFolder => fileFolderConfig.folder
fileFolder_recursions => fileFolderConfig.depth
fileFolder_extList => fileFolderConfig.allowedExtensions

Releases: main, 11.5