### PR TITLE
[TASK] Add hint for prefixParentPageSlug option

### DIFF
--- a/Documentation/ColumnsConfig/Type/Slug/Properties/GeneratorOptions.rst
+++ b/Documentation/ColumnsConfig/Type/Slug/Properties/GeneratorOptions.rst
@@ -69,6 +69,10 @@ generatorOptions
    Disable it for shorter URLs, but take the higher chance of collision into
    consideration.
 
+   .. note::
+
+      This option is exclusively for page records. It won't have an effect on any other records.
+
 .. confval:: generatorOptions:replacements
 
    :type: array


### PR DESCRIPTION
This option is used for core page records to create the
usual /foo/bar/baz url path. This feature does not work
for any other table and will be simply ignored.

Releases: main, 11.5, 10.4