### PR TITLE
[BUGFIX] Remove wrongly placed deprecation notice

### DIFF
--- a/Documentation/ColumnsConfig/Type/Inline/Properties/ForeignTable.rst
+++ b/Documentation/ColumnsConfig/Type/Inline/Properties/ForeignTable.rst
@@ -12,8 +12,3 @@ foreign\_table
    :Scope: Display  / Proc.
 
    The table name of the child records is defined here. The table must be configured in :php:`$GLOBALS['TCA']`.
-
-   .. deprecated:: 11.2
-      Usage of the `foreign_table` relation with the table `sys_language`
-      Has been deprecated. Use TCA field type called
-      :ref:`language<columns-language>` instead.


### PR DESCRIPTION
The deprecation for foreign_table => sys_language does
only apply to type=select.

Releases: main, 11.5