### PR TITLE
[BUGFIX] Correct default icon usage in `typeicon_classes`

### DIFF
--- a/Documentation/Ctrl/CtrlTypeiconClasses.rst.txt
+++ b/Documentation/Ctrl/CtrlTypeiconClasses.rst.txt
@@ -8,9 +8,11 @@ typeicon\_classes
     Display
 
 :aspect:`Description`
-    Array of names to use for the records. The keys must correspond to the values found in the column
+    Array of icon identifiers to use for the records. The keys must correspond to the values found in the column
     referenced in the :ref:`typeicon_column <ctrl-reference-typeicon-column>` property. The values correspond
-    to icons registered in the :ref:`Icon API <t3coreapi:icon>`. For using and configuring `typeicon_classes`
+    to icons registered in the :ref:`Icon API <t3coreapi:icon>`. With the key `default` a default icon is
+    defined which is used when no matching key is found. The default icon is as well used in the
+    "Create new record" dialog from the list module. For using and configuring `typeicon_classes`
     for custom page types, please see :ref:`Create a new Page Type<t3coreapi:page-types-example>`.
 
     **Example from the `tt_content` table:**
@@ -18,7 +20,7 @@ typeicon\_classes
     .. code-block:: php
 
         'typeicon_classes' => [
-            'header' => 'mimetypes-x-content-header',
             'default' => 'mimetypes-x-content-text',
+            'header' => 'mimetypes-x-content-header',
             ...
         ],

--- a/Documentation/Ctrl/CtrlTypeiconColumn.rst.txt
+++ b/Documentation/Ctrl/CtrlTypeiconColumn.rst.txt
@@ -8,8 +8,7 @@ typeicon\_column
     Display
 
 :aspect:`Description`
-    Field name, whose value decides *alternative icons* for the table records, the default icon
-    is the one defined with the :ref:`iconfile <ctrl-reference-iconfile>` value.
+    Field name, whose value decides *alternative icons* for the table records.
 
     The values in the field referenced by this property must match entries
     in the array defined in :ref:`typeicon_classes <ctrl-reference-typeicon-classes>`


### PR DESCRIPTION
releases: main, 11.5