### PR TITLE
[BUGFIX] Use correct code snippets/images

### DIFF
--- a/Documentation/ColumnsConfig/Type/Text/Properties/EnableTabulator.rst
+++ b/Documentation/ColumnsConfig/Type/Text/Properties/EnableTabulator.rst
@@ -10,8 +10,7 @@ enableTabulator
    :Path: $GLOBALS['TCA'][$table]['columns'][$field]['config']
    :type: boolean
    :Scope: Display
-   :RenderType: :ref:`textTable <columns-text-renderType-textTable>`,
-      :ref:`default <columns-text-renderType-default>`
+   :RenderType: :ref:`default <columns-text-renderType-default>`, :ref:`textTable <columns-text-renderType-textTable>`
 
    Enabling this allows to use tabs in a text field. This works well together with
    :ref:`fixed-width fonts <columns-text-properties-fixedFont>` (monospace) for code editing.
@@ -26,6 +25,6 @@ Examples
 Fixed font field with tabulators enabled
 ----------------------------------------
 
-.. include:: /Images/Rst/Text4.rst.txt
+.. include:: /Images/Rst/Text15.rst.txt
 
-.. include:: /CodeSnippets/Text4.rst.txt
+.. include:: /CodeSnippets/Text15.rst.txt

--- a/Documentation/ColumnsConfig/Type/Text/Properties/FixedFont.rst
+++ b/Documentation/ColumnsConfig/Type/Text/Properties/FixedFont.rst
@@ -11,9 +11,8 @@ fixedFont
    :Path: $GLOBALS['TCA'][$table]['columns'][$field]['config']
    :type: boolean
    :Scope: Display
-   :RenderType: :ref:`textTable <columns-text-renderType-textTable>`,
+   :RenderType: :ref:`default <columns-text-renderType-default>`, :ref:`textTable <columns-text-renderType-textTable>`
 
-   :ref:`default <columns-text-renderType-default>`
    Enables a fixed-width font (monospace) for the text field. This is useful when using code.
 
    Does not apply to RTE fields.
@@ -25,6 +24,6 @@ Examples
 Fixed font field with tabulators enabled
 ----------------------------------------
 
-.. include:: /Images/Rst/Text4.rst.txt
+.. include:: /Images/Rst/Text15.rst.txt
 
-.. include:: /CodeSnippets/Text4.rst.txt
+.. include:: /CodeSnippets/Text15.rst.txt


### PR DESCRIPTION
The examples for enableTabulator and fixedFont were incorrect.
The correct code snippet from styleguide is "text15".

As a drive-by: Fix render type list.

Releases: main, 11.5