### PR TITLE
[BUGFIX] Correct default icon usage in typeicon_classes

### DIFF
--- a/Documentation/Ctrl/Properties/TypeiconClasses.rst
+++ b/Documentation/Ctrl/Properties/TypeiconClasses.rst
@@ -13,9 +13,9 @@ typeicon\_classes
 
    Array of icon identifiers to use for the records. The keys must correspond to the values found in the column
    referenced in the :ref:`typeicon_column <ctrl-reference-typeicon-column>` property. The values correspond
-   to icons registered in the :ref:`Icon API <t3coreapi:icon>`. With the key `default` a default icon is
-   defined which is used when no matching key is found. The default icon is as well used in the
-   "Create new record" dialog from the list module. For using and configuring `typeicon_classes`
+   to icons registered in the :ref:`Icon API <t3coreapi:icon>`. With the key `default`, a default icon is
+   defined, which is used when no matching key is found. The default icon is also used in the
+   "Create new record" dialog from the List module. For using and configuring `typeicon_classes`
    for custom page types, please see :ref:`Create a new Page Type<t3coreapi:page-types-example>`.
 
 

--- a/Documentation/Ctrl/Properties/TypeiconClasses.rst
+++ b/Documentation/Ctrl/Properties/TypeiconClasses.rst
@@ -11,10 +11,11 @@ typeicon\_classes
    :type: array
    :Scope: Display
 
-
-   Array of names to use for the records. The keys must correspond to the values found in the column
+   Array of icon identifiers to use for the records. The keys must correspond to the values found in the column
    referenced in the :ref:`typeicon_column <ctrl-reference-typeicon-column>` property. The values correspond
-   to icons registered in the :ref:`Icon API <t3coreapi:icon>`. For using and configuring `typeicon_classes`
+   to icons registered in the :ref:`Icon API <t3coreapi:icon>`. With the key `default` a default icon is
+   defined which is used when no matching key is found. The default icon is as well used in the
+   "Create new record" dialog from the list module. For using and configuring `typeicon_classes`
    for custom page types, please see :ref:`Create a new Page Type<t3coreapi:page-types-example>`.
 
 
@@ -24,8 +25,8 @@ Examples
 Example from the `tt_content` table::
 
    'typeicon_classes' => [
-      'header' => 'mimetypes-x-content-header',
       'default' => 'mimetypes-x-content-text',
+      'header' => 'mimetypes-x-content-header',
       ...
    ],
 

--- a/Documentation/Ctrl/Properties/TypeiconColumn.rst
+++ b/Documentation/Ctrl/Properties/TypeiconColumn.rst
@@ -12,8 +12,7 @@ typeicon\_column
    :Scope: Display
 
 
-    Field name, whose value decides *alternative icons* for the table records, the default icon
-    is the one defined with the :ref:`iconfile <ctrl-reference-iconfile>` value.
+    Field name, whose value decides *alternative icons* for the table records.
 
     The values in the field referenced by this property must match entries
     in the array defined in :ref:`typeicon_classes <ctrl-reference-typeicon-classes>`


### PR DESCRIPTION
change of https://github.com/TYPO3-Documentation/TYPO3CMS-Reference-TCA/pull/525 applied for main

releases: main, 11.5