### PR TITLE
Do not use "record type" as the title.

### DIFF
--- a/Documentation/Ctrl/Properties/Type.rst
+++ b/Documentation/Ctrl/Properties/Type.rst
@@ -1,9 +1,9 @@
 .. include:: /Includes.rst.txt
 .. _ctrl-reference-type:
 
-============
-Record types
-============
+====
+type
+====
 
 .. confval:: type
 


### PR DESCRIPTION
I want to search for [$GLOBALS['TCA']['tx_news_domain_model_news']['ctrl']['type'].
It is only searchable if the title matches exactly the TCA array key name!