### PR TITLE
[FEATURE]  Feature: #97035 - Utilize “required” directly in TCA field…

### DIFF
--- a/Documentation/ColumnsConfig/CommonProperties/Index.rst
+++ b/Documentation/ColumnsConfig/CommonProperties/Index.rst
@@ -23,6 +23,7 @@ Common properties
    Multiple
    Placeholder
    ReadOnly
+   Required
    Search
    Size
    Softref

--- a/Documentation/ColumnsConfig/CommonProperties/Required.rst
+++ b/Documentation/ColumnsConfig/CommonProperties/Required.rst
@@ -1,0 +1,23 @@
+.. include:: /Includes.rst.txt
+.. _tca_property_required:
+
+========
+required
+========
+
+.. versionadded:: 12.0
+   This option should be used instead of an `eval` property with the
+   deprecated keyword `required`.
+
+.. confval:: required
+
+   :Path: $GLOBALS['TCA'][$table]['columns'][$field]['config']
+   :type: boolean
+   :Scope: Display / Proc.
+   :Default: false
+   :Types:
+      :ref:`input <columns-input>`,
+      :ref:`text <columns-text>`
+
+   If set to true a non-empty value is required in the field. Otherwise the
+   form cannot be saved.

--- a/Documentation/ColumnsConfig/Type/Input/Properties/Eval.rst
+++ b/Documentation/ColumnsConfig/Type/Input/Properties/Eval.rst
@@ -67,9 +67,6 @@ eval
       .. note::
          The value is visible while it is being entered!
 
-   required
-      A non-empty value is required in the field (otherwise the form cannot be saved).
-
    saltedPassword
       The value will be hashed using the password hash configuration for BE for all tables except :php:`fe_user`,
       where the password hash configuration for FE is used. Note this eval is typically only used core internally
@@ -99,6 +96,11 @@ eval
 
    Vendor\\Extension\\*
       User defined form evaluations.
+
+
+   .. deprecated:: 12.0
+      The keyword `required` is deprecated. Use the common property
+      :confval:`required` instead.
 
 Examples
 ========

--- a/Documentation/ColumnsConfig/Type/Input/Properties/Index.rst
+++ b/Documentation/ColumnsConfig/Type/Input/Properties/Index.rst
@@ -51,5 +51,6 @@ Common properties
 *  :ref:`mode <tca_property_mode>`
 *  :ref:`placeholder <tca_property_placeholder>`
 *  :ref:`readOnly <tca_property_readOnly>`
+*  :ref:`required <tca_property_required>`
 *  :ref:`search <tca_property_search>`
 *  :ref:`softref <tca_property_softref>`

--- a/Documentation/ColumnsConfig/Type/Text/Properties/Eval.rst
+++ b/Documentation/ColumnsConfig/Type/Text/Properties/Eval.rst
@@ -19,9 +19,6 @@ eval
 
    The evaluation functions will be executed in the list-order, available keywords:
 
-   required
-      A non-empty value is required in the field (otherwise the form cannot be saved).
-
    trim
       The value in the field will have white spaces around it trimmed away.
 
@@ -31,6 +28,10 @@ eval
 
    Vendor\\Extension\\*
       User defined form evaluations.
+
+   .. deprecated:: 12.0
+      The keyword `required` is deprecated. Use the common property
+      :confval:`required` instead.
 
 Examples
 ========

--- a/Documentation/ColumnsConfig/Type/Text/Properties/Index.rst
+++ b/Documentation/ColumnsConfig/Type/Text/Properties/Index.rst
@@ -20,3 +20,9 @@ Properties
    RichtextConfiguration
    Rows
    Wrap
+
+
+Common properties
+=================
+
+*  :ref:`required <tca_property_required>`


### PR DESCRIPTION
… configuration

https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/12.0/Feature-97035-UtilizeRequiredDirectlyInTCAFieldConfiguration.html

refs https://github.com/TYPO3-Documentation/TYPO3CMS-Reference-CoreApi/issues/1624