### PR TITLE
[BUGFIX] Fix typo in ShowNewRecordLink ref

### DIFF
--- a/Documentation/ColumnsConfig/Type/Inline/Properties/ShowNewRecordLink.rst
+++ b/Documentation/ColumnsConfig/Type/Inline/Properties/ShowNewRecordLink.rst
@@ -1,6 +1,6 @@
 .. include:: /Includes.rst.txt
 
-.. _columns-inline-properties-fshowNewRecordLink:
+.. _columns-inline-properties-showNewRecordLink:
 
 =================
 showNewRecordLink


### PR DESCRIPTION
Truly this is breaking, but this option is not so old
and probably hasn't many references to it if any at all.

Releases: main, 11.5