### PR TITLE
[BUGFIX] Bring label_alt and label_alt_force back to menu

### DIFF
--- a/Documentation/Ctrl/Properties/Index.rst
+++ b/Documentation/Ctrl/Properties/Index.rst
@@ -26,6 +26,8 @@ Properties
    Iconfile
    IsStatic
    Label
+   LabelAlt
+   LabelAltForce
    LabelUserfunc
    LanguageField
    OrigUid

--- a/Documentation/Ctrl/Properties/Label.rst
+++ b/Documentation/Ctrl/Properties/Label.rst
@@ -14,13 +14,18 @@ label
 
    **Required!**
 
-   Points to the field name of the table which should be used as the "title" when the record is displayed in the system.
+   Points to the field name of the table which should be used as the "title"
+   when the record is displayed in the system.
 
    .. note::
-      :ref:`label_userFunc <ctrl-reference-label-userfunc>` overrides this property (but it is still required).
+      :ref:`label_userFunc <ctrl-reference-label-userfunc>` overrides this
+      property (but it is still required).
 
    .. warning::
-      For the label only regular input or text fields should be used. Otherwise issues may occur and prevent from a working system if :code:`TCEMAIN.table.tt_content.disablePrependAtCopy` is not set or set to :code:`0`.
+      For the label only regular input or text fields should be used. Otherwise
+      issues may occur and prevent from a working system if
+      :typoscript:`TCEMAIN.table.tt_content.disablePrependAtCopy` is not set or
+      set to :typoscript:`0`.
 
 A simple example
 ----------------
@@ -28,52 +33,3 @@ A simple example
 .. include:: /Images/Rst/TxStyleguideCtrlMinimal.rst.txt
 
 .. include:: /CodeSnippets/TxStyleguideCtrlMinimal.rst.txt
-
-
-.. _ctrl-reference-label-alt:
-
-label\_alt
-==========
-
-.. confval:: label_alt
-
-   :type: String (comma-separated list of field names)
-   :Scope: Display
-
-
-   Comma-separated list of field names, which are holding alternative
-   values to the value from the field pointed to by "label" (see above)
-   if that value is empty. May not be used consistently in the system,
-   but should apply in most cases.
-
-   .. note::
-      :ref:`label_userFunc <ctrl-reference-label-userfunc>` overrides this property, also
-      see :ref:`label_alt_force <ctrl-reference-label-alt-force>`.
-
-Examples
---------
-
-Example for table "tt\_content"::
-
-   'ctrl' => [
-      'label' => 'header',
-      'label_alt' => 'subheader,bodytext',
-   ],
-
-
-.. _ctrl-reference-label-alt-force:
-
-label\_alt\_force
-=================
-
-.. confval:: label_alt_force
-
-   :type: boolean
-   :Scope: Display
-
-
-   If set, then the :ref:`label <ctrl-reference-label>` field and the :ref:`label_alt <ctrl-reference-label-alt>` fields
-   are shown in the title separated by comma.
-
-   .. note::
-      :ref:`label_userFunc <ctrl-reference-label-userfunc>` overrides this property.

--- a/Documentation/Ctrl/Properties/LabelAlt.rst
+++ b/Documentation/Ctrl/Properties/LabelAlt.rst
@@ -1,0 +1,32 @@
+.. include:: /Includes.rst.txt
+
+.. _ctrl-reference-label-alt:
+
+==========
+label\_alt
+==========
+
+.. confval:: label_alt
+
+   :type: String (comma-separated list of field names)
+   :Scope: Display
+
+
+   Comma-separated list of field names, which are holding alternative
+   values to the value from the field pointed to by "label" (see above)
+   if that value is empty. May not be used consistently in the system,
+   but should apply in most cases.
+
+   .. note::
+      :ref:`label_userFunc <ctrl-reference-label-userfunc>` overrides this property, also
+      see :ref:`label_alt_force <ctrl-reference-label-alt-force>`.
+
+Examples
+--------
+
+Example for table "tt\_content"::
+
+   'ctrl' => [
+      'label' => 'header',
+      'label_alt' => 'subheader,bodytext',
+   ],

--- a/Documentation/Ctrl/Properties/LabelAltForce.rst
+++ b/Documentation/Ctrl/Properties/LabelAltForce.rst
@@ -1,0 +1,21 @@
+.. include:: /Includes.rst.txt
+
+.. _ctrl-reference-label-alt-force:
+
+=================
+label\_alt\_force
+=================
+
+.. confval:: label_alt_force
+
+   :type: boolean
+   :Scope: Display
+
+
+   If set, then the :ref:`label <ctrl-reference-label>` field and the
+   :ref:`label_alt <ctrl-reference-label-alt>` fields
+   are shown in the title separated by comma.
+
+   .. note::
+      :ref:`label_userFunc <ctrl-reference-label-userfunc>` overrides this
+      property.


### PR DESCRIPTION
solves https://github.com/TYPO3-Documentation/TYPO3CMS-Reference-TCA/issues/518