### PR TITLE
[TASK] Document fileByUrlAllowed

### DIFF
--- a/Documentation/ColumnsConfig/Type/Inline/Properties/Appearance.rst
+++ b/Documentation/ColumnsConfig/Type/Inline/Properties/Appearance.rst
@@ -107,5 +107,10 @@ appearance
 
       The button is shown by default unless this option is set to :php:`false`.
 
+   fileByUrlAllowed (boolean)
+       Defines whether the button "Add media by URL" should be rendered. This button is used to include media
+       URLs from e.g. Vimeo or YouTube. In addition to this, a valid online media identifier must be listed
+       in the allowed list of :ref:`elementBrowserAllowed <columns-group-properties-appearance>`.
+
    elementBrowserEnabled (boolean)
       Hides or displays the element browser button in inline records


### PR DESCRIPTION
This option is available since TYPO3 v10.

See the according Changelog here:
https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/10.1/Feature-84250-SeparatelyEnableDisableAddMediaByURLAndSelectUploadFiles.html

Releases: main, 11.5, 10.4