### PR TITLE
[TASK] Remove unavailable "spec" linkHandler

### DIFF
--- a/Documentation/ColumnsConfig/Type/Input/Properties/LinkPopup.rst
+++ b/Documentation/ColumnsConfig/Type/Input/Properties/LinkPopup.rst
@@ -28,7 +28,7 @@ linkPopup
 
    blindLinkOptions (string, list)
       Comma separated list of link options that should not be displayed. Possible values are
-      `file`, `folder`, `mail`, `page`, `spec`, `telephone` and `url`. By default, all link options are displayed.
+      `file`, `folder`, `mail`, `page`, `telephone` and `url`. By default, all link options are displayed.
 
    title (string or LLL reference)
       Allows to set a different 'title' attribute to the popup icon, defaults


### PR DESCRIPTION
This option has been removed way back in TYPO3 v7.

Changelog file:
https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/7.4/Breaking-68116-DropRTEuserLinksFunctionality.html

Releases: 11.5, 10.4, 9.5