### PR TITLE
[TASK] Add example to linkPopup fieldControl documentation

### DIFF
--- a/Documentation/ColumnsConfig/Type/Input/Properties/LinkPopup.rst
+++ b/Documentation/ColumnsConfig/Type/Input/Properties/LinkPopup.rst
@@ -17,6 +17,22 @@ linkPopup
    The link browser control is typically used with `type='input'` with `renderType='inputLink'` adding a button
    which opens a modal to select an internal link to a page, an external link or a mail address.
 
+   **Example:**
+
+   .. code-block:: php
+
+      'aField' => [
+          'config' => [
+              'fieldControl' => [
+                  'linkPopup' => [
+                      'options' => [
+                          'blindLinkOptions' => 'file,folder',
+                      ],
+                  ],
+              ],
+          ],
+      ],
+
    **Options:**
 
    allowedExtensions (string, list)


### PR DESCRIPTION
New example for the TCA configuration of the fieldControl linkPopup.

This is helpful as the documentation does not specify that the options
are in another array with the key `options`.