### PR TITLE
Fix inconsistent indents

### DIFF
--- a/Documentation/ColumnsConfig/Type/Flex/FlexformSyntax.rst
+++ b/Documentation/ColumnsConfig/Type/Flex/FlexformSyntax.rst
@@ -72,12 +72,12 @@ Array Elements
     For <ROOT> elements in the DS you can add application specific information about the
     sheet that the <ROOT> element represents.
 
-   Child elements
-         <sheetTitle>
+    Child elements
+        <sheetTitle>
 
-         <sheetDescription>
+        <sheetDescription>
 
-         <sheetShortDescr>
+        <sheetShortDescr>
 
 
 .. _columns-flex-tceforms-value:
@@ -225,8 +225,8 @@ format. The structure is as follows:
     <[field name]>
     For each field name there is at least one element with the value, <vDEF>.
 
-   Child elements
-         <vDEF>
+    Child elements
+        <vDEF>
 
 
 .. _columns-flex-data-format-value:


### PR DESCRIPTION
The inconsistent indents resulted the content to be rendered
as quotes in some places.

Related: TYPO3-Documentation/T3DocTeam#150
Releases: main, 11.5, 10.4, 9.5

---

not part of commit message:

see rendered page: https://docs.typo3.org/m/typo3/reference-tca/main/en-us/ColumnsConfig/Type/Flex/FlexformSyntax.html 

**Note**: 4 spaces was used here because that is what is predominant on that page and in TCA reference. I made minimal changes only so much so that the quotes will no longer be used. In any case, the indenting should probably be unified at some point, see also https://github.com/TYPO3-Documentation/T3DocTeam/issues/191