### PR TITLE
Use ::class with class name instead of static string

### DIFF
--- a/Documentation/ColumnsConfig/Type/Input/Properties/Eval.rst
+++ b/Documentation/ColumnsConfig/Type/Input/Properties/Eval.rst
@@ -180,7 +180,7 @@ saving the record:
 .. code-block:: php
 
    // Register the class to be available in 'eval' of TCA
-   $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['tce']['formevals']['Vendor\\Extension\\Evaluation\\ExampleEvaluation'] = '';
+   $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['tce']['formevals'][\Vendor\Extension\Evaluation\ExampleEvaluation::class] = '';
 
 :file:`EXT:extension/Configuration/TCA/tx_example_record.php`:
 
@@ -190,7 +190,7 @@ saving the record:
       'example_field' => [
          'config' => [
             'type' => 'text',
-            'eval' => 'trim,Vendor\\Extension\\Evaluation\\ExampleEvaluation,required'
+            'eval' => 'trim,required,' . \Vendor\Extension\Evaluation\ExampleEvaluation::class
          ],
       ],
    ],


### PR DESCRIPTION
Resolves: #599
Resolves: #252
Releases: master, 11.5, 10.4

----

Not in commit: 

For v12, the fully qualified class name in ext_localconf.php can also be changed to the short class name (`ExampleEvaluation::class`) and "use" statements added. That can be done in separate PR/commit, so this patch here can be backported more easily.