### PR TITLE
Replace class name in static string in eval (v12 / main branch)

### DIFF
--- a/Documentation/ColumnsConfig/Type/Input/Properties/Eval.rst
+++ b/Documentation/ColumnsConfig/Type/Input/Properties/Eval.rst
@@ -175,22 +175,24 @@ saving the record:
       }
    }
 
-:file:`EXT:extension/ext_localconf.php`:
-
 .. code-block:: php
+   :caption: EXT:extension/ext_localconf.php
+
+   use Vendor\Extension\Evaluation\ExampleEvaluation;
+
+   // ....
 
    // Register the class to be available in 'eval' of TCA
-   $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['tce']['formevals']['Vendor\\Extension\\Evaluation\\ExampleEvaluation'] = '';
-
-:file:`EXT:extension/Configuration/TCA/tx_example_record.php`:
+   $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['tce']['formevals'][ExampleEvaluation::class] = '';
 
 .. code-block:: php
+   :caption: EXT:extension/Configuration/TCA/tx_example_record.php
 
    'columns' => [
       'example_field' => [
          'config' => [
             'type' => 'text',
-            'eval' => 'trim,Vendor\\Extension\\Evaluation\\ExampleEvaluation,required'
+            'eval' => 'trim,' . \Vendor\Extension\Evaluation\ExampleEvaluation::class
          ],
       ],
    ],

--- a/Documentation/ColumnsConfig/Type/Input/Properties/Eval.rst
+++ b/Documentation/ColumnsConfig/Type/Input/Properties/Eval.rst
@@ -192,6 +192,7 @@ saving the record:
       'example_field' => [
          'config' => [
             'type' => 'text',
+            'required' => true,
             'eval' => 'trim,' . \Vendor\Extension\Evaluation\ExampleEvaluation::class
          ],
       ],


### PR DESCRIPTION
Use ::class with class name instead of static string in the description
of the property eval.

Additionally, "required" is removed from the string, since this has been
moved to a separate property since v12.

Some captions reflecting the file names are added to the code blocks.
    
For v12, we can also add a "use" to ext_localconf.php to define the
full class name and use the short class name below.

Resolves: #599
Resolves: #252

---

Do not backport this PR - patches for other branch 11.5 will be supplied with a separate PR.