### PR TITLE
Replace class name in static string in eval (v11 branch)

### DIFF
--- a/Documentation/ColumnsConfig/Type/Input/Properties/Eval.rst
+++ b/Documentation/ColumnsConfig/Type/Input/Properties/Eval.rst
@@ -185,22 +185,20 @@ saving the record:
       }
    }
 
-:file:`EXT:extension/ext_localconf.php`:
-
 .. code-block:: php
+   :caption: EXT:extension/ext_localconf.php
 
    // Register the class to be available in 'eval' of TCA
-   $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['tce']['formevals']['Vendor\\Extension\\Evaluation\\ExampleEvaluation'] = '';
-
-:file:`EXT:extension/Configuration/TCA/tx_example_record.php`:
+   $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['tce']['formevals'][\Vendor\Extension\Evaluation\ExampleEvaluation::class] = '';
 
 .. code-block:: php
+   :caption: EXT:extension/Configuration/TCA/tx_example_record.php
 
    'columns' => [
       'example_field' => [
          'config' => [
             'type' => 'text',
-            'eval' => 'trim,Vendor\\Extension\\Evaluation\\ExampleEvaluation,required'
+            'eval' => 'trim,required,' . \Vendor\Extension\Evaluation\ExampleEvaluation::class
          ],
       ],
    ],


### PR DESCRIPTION
Use ::class with class name instead of static string in the description
of the property eval.

Some captions reflecting the file names are added to the code blocks.

Resolves: #599
Resolves: #252