### PR TITLE
Add example for fieldInformation for type inline

### DIFF
--- a/Documentation/ColumnsConfig/Type/Inline/Examples.rst
+++ b/Documentation/ColumnsConfig/Type/Inline/Examples.rst
@@ -136,3 +136,98 @@ added to the parent record.
 
 .. include:: /CodeSnippets/InlineUsecombinationcInline1.rst.txt
 
+.. _inline-example-field-information:
+
+Add a custom fieldInformation
+=============================
+
+We show a very minimal example which adds a custom fieldInformation for the
+inline type in tt_content. Adding a fieldWizard is done in a similar way.
+
+As explained in the :ref:`description <columns-inline>`, :code:`fieldInformation`
+or :code:`fieldWizard` must be configured within the :code:`ctrl` **for the field
+type inline** - as it is a container.
+
+.. rst-class:: bignums-xxl
+
+#. Create a custom fieldInformation
+
+   .. code-block:: php
+      :caption: EXT:my_extension/Classes/FormEngine/FieldInformation/DemoFieldInformation
+
+         <?php
+         declare(strict_types=1);
+         namespace Myvendor\Myexample\FormEngine\FieldInformation;
+
+         use TYPO3\CMS\Backend\Form\AbstractNode;
+
+         class DemoFieldInformation extends AbstractNode
+         {
+             public function render()
+             {
+                 $result = $this->initializeResultArray();
+
+                  // Add fieldInformation only for this field name
+                  //   this may be changed accoringly
+                  if ($fieldName !== 'my_new_field') {
+                      return $result;
+                  }
+                  $text = $GLOBALS['LANG']->sL(
+                          'LLL:EXT:my_example/Resources/Private/Language/'
+                          . 'locallang_db.xlf:tt_content.fieldInformation.demo'
+                  );
+                  $result['html'] = $text;
+                  );
+                  return $result;
+             }
+         }
+
+#. Register this node type
+
+   .. code-block:: php
+      :caption: EXT:my_extension/ext_localconf.php
+
+         <?php
+         use Myvendor\Myexample\FormEngine\FieldInformation\DemoFieldInformation;
+
+         // ...
+
+         $GLOBALS['TYPO3_CONF_VARS']['SYS']['formEngine']['nodeRegistry'][1654355506] = [
+             'nodeName' => 'demoFieldInformation',
+             'priority' => 30,
+             'class' => DemoFieldInformation::class,
+         ];
+
+#. Add the fieldInformation to the container for containerRenderType inline
+
+   .. code-block:: php
+      :caption: EXT:my_extension/Configuration/TCA/Overrrides/tt_content.php
+
+          $GLOBALS['TCA']['tt_content']['ctrl']['container']['inline']['fieldInformation'] = [
+              'demoFieldInformation' => [
+                  'renderType' => 'demoFieldInformation',
+              ],
+          ];
+
+#. A field my_new_field is created in the tt_content TCA:
+
+   .. code-block:: php
+      :caption: EXT:my_extension/Configuration/TCA/Overrides/tt_content.php
+
+          'my_new_field2' => [
+              'label' => 'inline field with field information',
+              'config' => [
+                  'type' => 'inline',
+                  // further configuration can be found in the examples above
+                  // ....
+              ],
+          ],
+          // ...
+
+.. seealso::
+
+   *  :ref:`['ctrl']['container'] <ctrl-reference-container>`
+   *  How to create custom fieldInformation, fieldControl or fieldWizard in
+      :ref:`FormEngine <FormEngine-Rendering-NodeExpansion>` chapter (TYPO3
+      Explained)
+   *  :ref:`fieldInformation <tca_property_fieldInformation>` property

--- a/Documentation/ColumnsConfig/Type/Inline/Index.rst
+++ b/Documentation/ColumnsConfig/Type/Inline/Index.rst
@@ -27,6 +27,15 @@ question (for instance a description). This information can be overwritten for t
 "tt_content" by adding a new description in table "sys_file_reference". The various inline and field properties
 like "placeholder" help managing this complex setup in TCA.
 
+.. hint::
+
+   The type inline does not have the properties :code:`fieldInformation`,
+   :code:`fieldControl` or :code:`fieldWizard` like the other types. This is
+   due to the fact that this type is a container and not an element. You can
+   still add fieldInformation or fieldWizard, but this must be configured
+   within the :code:`ctrl`. Please see the
+   :ref:`example <inline-example-field-information>`.
+
 .. toctree::
    :titlesonly:
 

--- a/Documentation/Ctrl/Properties/Container.rst
+++ b/Documentation/Ctrl/Properties/Container.rst
@@ -105,3 +105,8 @@ In PHP, the node has to implement an interface, but can return any additional HT
 "OuterWrapContainer" between the record title and the field body when editing a record:
 
 .. include:: /Images/ManualScreenshots/OuterFieldWizard.rst.txt
+
+Add fieldInformation to field of type inline
+--------------------------------------------
+
+This example can be found in :ref:`inline-example-field-information`.


### PR DESCRIPTION
As pointed out differently, fieldInformation and fieldWizard must
be configured differently for type inline. An example is added
to address this. Also, a note is added in the description and
several links linking between the various places where this is
relevant.

Resolves: #186

-----

Not in commit: except for the "use" in ext_localconf.php, I think this could also be backported to v11.