### PR TITLE
Clarify ctrl | container page

### DIFF
--- a/Documentation/Ctrl/Properties/Container.rst
+++ b/Documentation/Ctrl/Properties/Container.rst
@@ -26,12 +26,12 @@ container
 
       'ctrl' => [
          'container' => [
-            'containerRenderType' => [
+            '<containerRenderType>' => [
                'fieldWizard' => [
-                  'aName' => [
-                     'renderType' => 'aRenderType',
-                     'before' => ['anotherName'],
-                     'after' => ['yetAnotherName'],
+                  '<aName>' => [
+                     'renderType' => '<aRenderType>',
+                     'before' => ['<anotherName>'],
+                     'after' => ['<yetAnotherName>'],
                      'disabled' => false,
                      'options' => [],
                   ],
@@ -40,16 +40,34 @@ container
          ],
       ],
 
-   -  "renderType" refers to a registered node name from :php:`NodeFactory`
+   <containerRenderType>
+      should be a defined container render type.
+      You can find more about the :code:`outerWrapContainer` and
+      :code:`inlineControlContainer` in the FormEngine documentation section on
+      :ref:`rendering <t3coreapi:FormEngine-Rendering>`.
+      Valid types are for example:
 
-   -  "before" and "after" can be set to sort single wizards relative to each other.
+      -  :code:`outerWrapContainer` type which corresponds to the
+         :php:`OuterWrapContainer` (class).
+      -  :code:`inlineControlContainer` type which corresponds to the
+         :php:`InlineControlContainer` class
+      -  :code:`inline` type which corresponds to the :php:`InlineControlContainer`
+         class.
 
-   -  "disabled" can be used to disable built in default wizards.
+   renderType
+      refers to a registered node name from :php:`NodeFactory`
 
-   -  Some wizards may support additional "options".
+   before, after
+      can be set to sort single wizards relative to each other.
 
-   -  Note, next to "fieldWizard", some containers may also implement "fieldInformation", which can be
-      manipulated the same way.
+   disabled
+      can be used to disable built in default wizards.
+
+   options
+      Some wizards may support additional "options".
+
+   Note, next to "fieldWizard", some containers may also implement "fieldInformation", which can be
+   manipulated the same way.
 
 Examples
 ========


### PR DESCRIPTION
The control container page is improved by changing some
formatting and adding clarifications:

1. In the code snippets, if one is not familiar (yet)
   with the example, it is difficult to distinguish
   between strings which should be used verbatim (as is)
   such as "renderType" and strings which are used as
   placeholders. This patch changes the placeholder
   strings to be enclosed in angle brackets <>. Since this
   is in a string, it should not be a problem for
   the lexers when performing the syntax highlighting.

   Mostly, this was done for <containerRenderType> where
   a valid container render type should be inserted.

2. For the explanation of the parts in the code snippet,
   a definition list is used which results in better
   formatting, highlighting the string which is explained

3. The containerRenderType is also added in the list of
   options

4. A distinction is made between the class name
   (in UpperCamelCase) and the type (in lowerCamelCase).

   This can also avoid confusion when trying to use the
   class name instead of the type in TCA configuration.

5. Examples for valid container render types are added

6. We refer to the FormEngine docs where the OuterWrapContainer
   is used in one of the diagrams which might make this
   more clear

Related: #186

--- 

Not in commit: 

----

Using the placeholders in angle brackets is also explained in "Writing Documentation": https://docs.typo3.org/m/typo3/docs-how-to-document/main/en-us/WritingReST/Codeblocks.html




----

rendered output:

**before**

![image](https://user-images.githubusercontent.com/13206455/172044528-0b75978a-4388-4e52-b5d1-e2cba5b72002.png)


**after**:

![image](https://user-images.githubusercontent.com/13206455/172044509-62e1d593-6164-464e-b093-2910d5448bd0.png)

