### PR TITLE
[BUGFIX] Link to restriction builder in TYPO3 Explained correctly

### DIFF
--- a/Documentation/Ctrl/Properties/Enablecolumns.rst
+++ b/Documentation/Ctrl/Properties/Enablecolumns.rst
@@ -89,7 +89,7 @@ Using the QueryBuilder
 The same is true when
 :ref:`select() is called on the connection <t3coreapi:database-connection-select>`.
 
-See the :ref:`<t3coreapi:database-restriction-builder>` for details.
+See the :ref:`t3coreapi:database-restriction-builder` for details.
 
 However this could be disabled by setting:
 


### PR DESCRIPTION
Releases: main, 11.5