### PR TITLE
[BUGFIX] Correct caption of code snippet

### DIFF
--- a/Documentation/CodeSnippets/Manual/Ctrl/DataHandlerFields.rst.txt
+++ b/Documentation/CodeSnippets/Manual/Ctrl/DataHandlerFields.rst.txt
@@ -1,5 +1,5 @@
 .. code-block:: php
-   :caption: EXT:my_extension/Configuration/Backend/BackendAjaxRoutes.php
+   :caption: EXT:my_extension/Configuration/TCA/tx_myextension_domain_model_mytable.php
 
    <?php
 


### PR DESCRIPTION
Displayed is a TCA snippet, not a backend route. Included,
for example, on tstamp page:
https://docs.typo3.org/m/typo3/reference-tca/11.5/en-us/Ctrl/Properties/Tstamp.html

Releases: main, 11.5