### PR TITLE
Remove inappropriate example

### DIFF
--- a/Documentation/Columns/Properties/Exclude.rst
+++ b/Documentation/Columns/Properties/Exclude.rst
@@ -18,3 +18,23 @@ exclude
 
    See :ref:`Access lists <t3coreapi:access-options-access-lists>` for more
    about permissions.
+
+Example
+=======
+
+Simple input field
+------------------
+
+.. code-block:: php
+   [
+       'columns' => [
+           'input_2' => [
+               'label' => 'input_2 description',
+               'exclude' => true,
+               'config' => [
+                   'type' => 'input',
+                   
+               ],
+           ],
+       ],
+   ]

--- a/Documentation/Columns/Properties/Exclude.rst
+++ b/Documentation/Columns/Properties/Exclude.rst
@@ -26,6 +26,7 @@ Simple input field
 ------------------
 
 .. code-block:: php
+
    [
        'columns' => [
            'input_2' => [

--- a/Documentation/Columns/Properties/Exclude.rst
+++ b/Documentation/Columns/Properties/Exclude.rst
@@ -18,13 +18,3 @@ exclude
 
    See :ref:`Access lists <t3coreapi:access-options-access-lists>` for more
    about permissions.
-
-Example
-=======
-
-Simple input field
-------------------
-
-.. include:: /Images/Rst/Input1.rst.txt
-
-.. include:: /CodeSnippets/Input1.rst.txt


### PR DESCRIPTION
The example does not show the property èxclude`. So it has no added value for the user.

I think 'exclude' is self-explanatory enough that it doesn't need an example/image to illustrate its use.