### PR TITLE
Add edge case info about category type

### DIFF
--- a/Documentation/ColumnsConfig/Type/Category/Index.rst
+++ b/Documentation/ColumnsConfig/Type/Category/Index.rst
@@ -1,4 +1,4 @@
-﻿.. include:: /Includes.rst.txt
+.. include:: /Includes.rst.txt
 
 .. _columns-category:
 
@@ -29,12 +29,13 @@ The following options can be overridden via :ref:`page TSconfig, TCE form
 *  `readOnly`
 *  `treeConfig`
 
-
 .. note::
 
    It is still possible to configure a category tree with `type=select`
    and `renderType=selectTree`. This configuration will still work, but
    it can in most cases be simplified by using the new :php:`category` TCA type.
+   However if you need to modifiy e. g. the `foreign_table_where` field, you
+   need to replicate the category type configuration manually to do so.
 
 
 .. toctree::

--- a/Documentation/ColumnsConfig/Type/Category/Index.rst
+++ b/Documentation/ColumnsConfig/Type/Category/Index.rst
@@ -32,10 +32,9 @@ The following options can be overridden via :ref:`page TSconfig, TCE form
 .. note::
 
    It is still possible to configure a category tree with `type=select`
-   and `renderType=selectTree`. This configuration will still work, but
-   it can in most cases be simplified by using the new :php:`category` TCA type.
-   However if you need to modifiy e. g. the `foreign_table_where` field, you
-   need to replicate the category type configuration manually to do so.
+   and `renderType=selectTree` when you want to override specific fields
+   like e. g. the `foreign_table_where` field, but in most cases the
+   simplified :php:`category` TCA type is sufficient.
 
 
 .. toctree::


### PR DESCRIPTION
While the documentation states that you can override some fields, I feel the need to indicate that there are edge cases where `type=category` is not suitable. What do you think?

Is it possible to add the hacktoberfest-accepted label?