### PR TITLE
[Backport 11.5][TASK] Move Codesnippets.php

### DIFF
--- a/Documentation/codesnippets.php
+++ b/Documentation/codesnippets.php
@@ -7,7 +7,7 @@ return [
         'action' => 'createPhpArrayCodeSnippet',
         'sourceFile' => 'typo3/sysext/core/Configuration/TCA/be_groups.php',
         'fields' => ['columns/file_mountpoints'],
-        'targetFileName' => 'FileMountpoints.rst.txt',
+        'targetFileName' => 'CodeSnippets/FileMountpoints.rst.txt',
     ],
 
 
@@ -15,732 +15,732 @@ return [
         'action' => 'createPhpArrayCodeSnippet',
         'sourceFile' => 'typo3/sysext/frontend/Configuration/TCA/tt_content.php',
         'fields' => ['columns/hidden'],
-        'targetFileName' => 'TtContentHidden.rst.txt'
+        'targetFileName' => 'CodeSnippets/TtContentHidden.rst.txt'
     ],
     [
         'action' => 'createPhpArrayCodeSnippet',
         'sourceFile' => 'typo3/sysext/frontend/Configuration/TCA/tt_content.php',
         'fields' => ['ctrl'],
-        'targetFileName' => 'TtContentCtrl.rst.txt'
+        'targetFileName' => 'CodeSnippets/TtContentCtrl.rst.txt'
     ],
 
     [
         'action' => 'createPhpArrayCodeSnippet',
         'sourceFile' => 'typo3conf/ext/styleguide/Configuration/TCA/tx_styleguide_inline_fal.php',
         'fields' => ['columns/inline_1'],
-        'targetFileName' => 'InlineFalInline1.rst.txt'
+        'targetFileName' => 'CodeSnippets/InlineFalInline1.rst.txt'
     ],
     [
         'action' => 'createPhpArrayCodeSnippet',
         'sourceFile' => 'typo3conf/ext/styleguide/Configuration/TCA/tx_styleguide_inline_fal.php',
         'fields' => ['columns/inline_flex_1'],
-        'targetFileName' => 'InlineFalInline1Flexform.rst.txt'
+        'targetFileName' => 'CodeSnippets/InlineFalInline1Flexform.rst.txt'
     ],
 
     [
         'action' => 'createPhpArrayCodeSnippet',
         'sourceFile' => 'typo3conf/ext/styleguide/Configuration/TCA/tx_styleguide_elements_basic.php',
         'fields' => ['columns/sys_language_uid'],
-        'targetFileName' => 'SysLanguageUid.rst.txt'
+        'targetFileName' => 'CodeSnippets/SysLanguageUid.rst.txt'
     ],
 
     [
         'action' => 'createPhpArrayCodeSnippet',
         'sourceFile' => 'typo3conf/ext/styleguide/Configuration/TCA/tx_styleguide_elements_basic.php',
         'fields' => ['columns/input_1'],
-        'targetFileName' => 'Input1.rst.txt'
+        'targetFileName' => 'CodeSnippets/Input1.rst.txt'
     ],
 
     [
         'action' => 'createPhpArrayCodeSnippet',
         'sourceFile' => 'typo3conf/ext/styleguide/Configuration/TCA/tx_styleguide_elements_basic.php',
         'fields' => ['columns/input_28'],
-        'targetFileName' => 'Input28.rst.txt'
+        'targetFileName' => 'CodeSnippets/Input28.rst.txt'
     ],
 
     [
         'action' => 'createPhpArrayCodeSnippet',
         'sourceFile' => 'typo3conf/ext/styleguide/Configuration/TCA/tx_styleguide_elements_basic.php',
         'fields' => ['columns/input_30'],
-        'targetFileName' => 'Input30.rst.txt'
+        'targetFileName' => 'CodeSnippets/Input30.rst.txt'
     ],
 
     [
         'action' => 'createPhpArrayCodeSnippet',
         'sourceFile' => 'typo3conf/ext/styleguide/Configuration/TCA/tx_styleguide_elements_basic.php',
         'fields' => ['columns/input_33'],
-        'targetFileName' => 'Input33.rst.txt'
+        'targetFileName' => 'CodeSnippets/Input33.rst.txt'
     ],
 
     [
         'action' => 'createPhpArrayCodeSnippet',
         'sourceFile' => 'typo3conf/ext/styleguide/Configuration/TCA/tx_styleguide_elements_basic.php',
         'fields' => ['columns/radio_1'],
-        'targetFileName' => 'Radio1.rst.txt'
+        'targetFileName' => 'CodeSnippets/Radio1.rst.txt'
     ],
 
     [
         'action' => 'createPhpArrayCodeSnippet',
         'sourceFile' => 'typo3conf/ext/styleguide/Configuration/TCA/tx_styleguide_elements_basic.php',
         'fields' => ['columns/checkbox_2'],
-        'targetFileName' => 'Checkbox2.rst.txt'
+        'targetFileName' => 'CodeSnippets/Checkbox2.rst.txt'
     ],
 
     [
         'action' => 'createPhpArrayCodeSnippet',
         'sourceFile' => 'typo3conf/ext/styleguide/Configuration/TCA/tx_styleguide_elements_basic.php',
         'fields' => ['columns/checkbox_3'],
-        'targetFileName' => 'Checkbox3.rst.txt'
+        'targetFileName' => 'CodeSnippets/Checkbox3.rst.txt'
     ],
 
     [
         'action' => 'createPhpArrayCodeSnippet',
         'sourceFile' => 'typo3conf/ext/styleguide/Configuration/TCA/tx_styleguide_elements_basic.php',
         'fields' => ['columns/checkbox_7'],
-        'targetFileName' => 'Checkbox7.rst.txt'
+        'targetFileName' => 'CodeSnippets/Checkbox7.rst.txt'
     ],
 
     [
         'action' => 'createPhpArrayCodeSnippet',
         'sourceFile' => 'typo3conf/ext/styleguide/Configuration/TCA/tx_styleguide_elements_basic.php',
         'fields' => ['columns/checkbox_8'],
-        'targetFileName' => 'Checkbox8.rst.txt'
+        'targetFileName' => 'CodeSnippets/Checkbox8.rst.txt'
     ],
 
     [
         'action' => 'createPhpArrayCodeSnippet',
         'sourceFile' => 'typo3conf/ext/styleguide/Configuration/TCA/tx_styleguide_elements_basic.php',
         'fields' => ['columns/checkbox_12'],
-        'targetFileName' => 'Checkbox12.rst.txt'
+        'targetFileName' => 'CodeSnippets/Checkbox12.rst.txt'
     ],
 
     [
         'action' => 'createPhpArrayCodeSnippet',
         'sourceFile' => 'typo3conf/ext/styleguide/Configuration/TCA/tx_styleguide_elements_basic.php',
         'fields' => ['columns/checkbox_16'],
-        'targetFileName' => 'Checkbox16.rst.txt'
+        'targetFileName' => 'CodeSnippets/Checkbox16.rst.txt'
     ],
 
     [
         'action' => 'createPhpArrayCodeSnippet',
         'sourceFile' => 'typo3conf/ext/styleguide/Configuration/TCA/tx_styleguide_elements_basic.php',
         'fields' => ['columns/checkbox_17'],
-        'targetFileName' => 'Checkbox17.rst.txt'
+        'targetFileName' => 'CodeSnippets/Checkbox17.rst.txt'
     ],
 
     [
         'action' => 'createPhpArrayCodeSnippet',
         'sourceFile' => 'typo3conf/ext/styleguide/Configuration/TCA/tx_styleguide_elements_basic.php',
         'fields' => ['columns/checkbox_18'],
-        'targetFileName' => 'Checkbox18.rst.txt'
+        'targetFileName' => 'CodeSnippets/Checkbox18.rst.txt'
     ],
 
     [
         'action' => 'createPhpArrayCodeSnippet',
         'sourceFile' => 'typo3conf/ext/styleguide/Configuration/TCA/tx_styleguide_elements_basic.php',
         'fields' => ['columns/checkbox_19'],
-        'targetFileName' => 'Checkbox19.rst.txt'
+        'targetFileName' => 'CodeSnippets/Checkbox19.rst.txt'
     ],
 
     [
         'action' => 'createPhpArrayCodeSnippet',
         'sourceFile' => 'typo3conf/ext/styleguide/Configuration/TCA/tx_styleguide_elements_basic.php',
         'fields' => ['columns/checkbox_21'],
-        'targetFileName' => 'Checkbox21.rst.txt'
+        'targetFileName' => 'CodeSnippets/Checkbox21.rst.txt'
     ],
 
     [
         'action' => 'createPhpArrayCodeSnippet',
         'sourceFile' => 'typo3conf/ext/styleguide/Configuration/TCA/tx_styleguide_elements_basic.php',
         'fields' => ['columns/text_4'],
-        'targetFileName' => 'Text4.rst.txt'
+        'targetFileName' => 'CodeSnippets/Text4.rst.txt'
     ],
 
     [
         'action' => 'createPhpArrayCodeSnippet',
         'sourceFile' => 'typo3conf/ext/styleguide/Configuration/TCA/tx_styleguide_elements_basic.php',
         'fields' => ['columns/text_5'],
-        'targetFileName' => 'Text5.rst.txt'
+        'targetFileName' => 'CodeSnippets/Text5.rst.txt'
     ],
 
     [
         'action' => 'createPhpArrayCodeSnippet',
         'sourceFile' => 'typo3conf/ext/styleguide/Configuration/TCA/tx_styleguide_elements_basic.php',
         'fields' => ['columns/text_6'],
-        'targetFileName' => 'Text6.rst.txt'
+        'targetFileName' => 'CodeSnippets/Text6.rst.txt'
     ],
 
     [
         'action' => 'createPhpArrayCodeSnippet',
         'sourceFile' => 'typo3conf/ext/styleguide/Configuration/TCA/tx_styleguide_elements_basic.php',
         'fields' => ['columns/text_7'],
-        'targetFileName' => 'Text7.rst.txt'
+        'targetFileName' => 'CodeSnippets/Text7.rst.txt'
     ],
 
     [
         'action' => 'createPhpArrayCodeSnippet',
         'sourceFile' => 'typo3conf/ext/styleguide/Configuration/TCA/tx_styleguide_elements_basic.php',
         'fields' => ['columns/text_9'],
-        'targetFileName' => 'Text9.rst.txt'
+        'targetFileName' => 'CodeSnippets/Text9.rst.txt'
     ],
 
     [
         'action' => 'createPhpArrayCodeSnippet',
         'sourceFile' => 'typo3conf/ext/styleguide/Configuration/TCA/tx_styleguide_elements_basic.php',
         'fields' => ['columns/text_11'],
-        'targetFileName' => 'Text11.rst.txt'
+        'targetFileName' => 'CodeSnippets/Text11.rst.txt'
     ],
 
     [
         'action' => 'createPhpArrayCodeSnippet',
         'sourceFile' => 'typo3conf/ext/styleguide/Configuration/TCA/tx_styleguide_elements_basic.php',
         'fields' => ['columns/text_14'],
-        'targetFileName' => 'Text14.rst.txt'
+        'targetFileName' => 'CodeSnippets/Text14.rst.txt'
     ],
 
     [
         'action' => 'createPhpArrayCodeSnippet',
         'sourceFile' => 'typo3conf/ext/styleguide/Configuration/TCA/tx_styleguide_elements_basic.php',
         'fields' => ['columns/text_15'],
-        'targetFileName' => 'Text15.rst.txt'
+        'targetFileName' => 'CodeSnippets/Text15.rst.txt'
     ],
 
     [
         'action' => 'createPhpArrayCodeSnippet',
         'sourceFile' => 'typo3conf/ext/styleguide/Configuration/TCA/tx_styleguide_elements_basic.php',
         'fields' => ['columns/text_17'],
-        'targetFileName' => 'Text17.rst.txt'
+        'targetFileName' => 'CodeSnippets/Text17.rst.txt'
     ],
 
     [
         'action' => 'createPhpArrayCodeSnippet',
         'sourceFile' => 'typo3conf/ext/styleguide/Configuration/TCA/tx_styleguide_elements_basic.php',
         'fields' => ['columns/text_18'],
-        'targetFileName' => 'Text18.rst.txt'
+        'targetFileName' => 'CodeSnippets/Text18.rst.txt'
     ],
 
     [
         'action' => 'createPhpArrayCodeSnippet',
         'sourceFile' => 'typo3conf/ext/styleguide/Configuration/TCA/tx_styleguide_elements_basic.php',
         'fields' => ['columns/text_19'],
-        'targetFileName' => 'Text19.rst.txt'
+        'targetFileName' => 'CodeSnippets/Text19.rst.txt'
     ],
 
     [
         'action' => 'createPhpArrayCodeSnippet',
         'sourceFile' => 'typo3conf/ext/styleguide/Configuration/TCA/tx_styleguide_elements_basic.php',
         'fields' => ['columns/text_20'],
-        'targetFileName' => 'Text20.rst.txt'
+        'targetFileName' => 'CodeSnippets/Text20.rst.txt'
     ],
 
     [
         'action' => 'createPhpArrayCodeSnippet',
         'sourceFile' => 'typo3conf/ext/styleguide/Configuration/TCA/tx_styleguide_elements_basic.php',
         'fields' => ['columns/text_2'],
-        'targetFileName' => 'TranslatedText2.rst.txt'
+        'targetFileName' => 'CodeSnippets/TranslatedText2.rst.txt'
     ],
 
     [
         'action' => 'createPhpArrayCodeSnippet',
         'sourceFile' => 'typo3conf/ext/styleguide/Configuration/TCA/tx_styleguide_elements_basic.php',
         'fields' => ['columns/none_1'],
-        'targetFileName' => 'None1.rst.txt'
+        'targetFileName' => 'CodeSnippets/None1.rst.txt'
     ],
     [
         'action' => 'createPhpArrayCodeSnippet',
         'sourceFile' => 'typo3conf/ext/styleguide/Configuration/TCA/tx_styleguide_elements_select.php',
         'fields' => ['columns/select_checkbox_1'],
-        'targetFileName' => 'SelectCheckbox1.rst.txt'
+        'targetFileName' => 'CodeSnippets/SelectCheckbox1.rst.txt'
     ],
 
     [
         'action' => 'createPhpArrayCodeSnippet',
         'sourceFile' => 'typo3conf/ext/styleguide/Configuration/TCA/tx_styleguide_elements_select.php',
         'fields' => ['columns/select_checkbox_2'],
-        'targetFileName' => 'SelectCheckbox2.rst.txt'
+        'targetFileName' => 'CodeSnippets/SelectCheckbox2.rst.txt'
     ],
 
     [
         'action' => 'createPhpArrayCodeSnippet',
         'sourceFile' => 'typo3conf/ext/styleguide/Configuration/TCA/tx_styleguide_elements_select.php',
         'fields' => ['columns/select_checkbox_3'],
-        'targetFileName' => 'SelectCheckbox3.rst.txt'
+        'targetFileName' => 'CodeSnippets/SelectCheckbox3.rst.txt'
     ],
 
     [
         'action' => 'createPhpArrayCodeSnippet',
         'sourceFile' => 'typo3conf/ext/styleguide/Configuration/TCA/tx_styleguide_elements_select.php',
         'fields' => ['columns/select_checkbox_5'],
-        'targetFileName' => 'SelectCheckbox5.rst.txt'
+        'targetFileName' => 'CodeSnippets/SelectCheckbox5.rst.txt'
     ],
 
     [
         'action' => 'createPhpArrayCodeSnippet',
         'sourceFile' => 'typo3conf/ext/styleguide/Configuration/TCA/tx_styleguide_elements_select.php',
         'fields' => ['columns/select_checkbox_7'],
-        'targetFileName' => 'SelectCheckbox7.rst.txt'
+        'targetFileName' => 'CodeSnippets/SelectCheckbox7.rst.txt'
     ],
 
     [
         'action' => 'createPhpArrayCodeSnippet',
         'sourceFile' => 'typo3conf/ext/styleguide/Configuration/TCA/tx_styleguide_elements_select.php',
         'fields' => ['columns/select_multiplesidebyside_1'],
-        'targetFileName' => 'SelectMultiplesidebyside1.rst.txt'
+        'targetFileName' => 'CodeSnippets/SelectMultiplesidebyside1.rst.txt'
     ],
 
     [
         'action' => 'createPhpArrayCodeSnippet',
         'sourceFile' => 'typo3conf/ext/styleguide/Configuration/TCA/tx_styleguide_elements_select.php',
         'fields' => ['columns/select_multiplesidebyside_2'],
-        'targetFileName' => 'SelectMultiplesidebyside2.rst.txt'
+        'targetFileName' => 'CodeSnippets/SelectMultiplesidebyside2.rst.txt'
     ],
 
     [
         'action' => 'createPhpArrayCodeSnippet',
         'sourceFile' => 'typo3conf/ext/styleguide/Configuration/TCA/tx_styleguide_elements_select.php',
         'fields' => ['columns/select_multiplesidebyside_5'],
-        'targetFileName' => 'SelectMultiplesidebyside5.rst.txt'
+        'targetFileName' => 'CodeSnippets/SelectMultiplesidebyside5.rst.txt'
     ],
 
     [
         'action' => 'createPhpArrayCodeSnippet',
         'sourceFile' => 'typo3conf/ext/styleguide/Configuration/TCA/tx_styleguide_elements_select.php',
         'fields' => ['columns/select_multiplesidebyside_6'],
-        'targetFileName' => 'SelectMultiplesidebyside6.rst.txt'
+        'targetFileName' => 'CodeSnippets/SelectMultiplesidebyside6.rst.txt'
     ],
 
     [
         'action' => 'createPhpArrayCodeSnippet',
         'sourceFile' => 'typo3conf/ext/styleguide/Configuration/TCA/tx_styleguide_elements_select.php',
         'fields' => ['columns/select_multiplesidebyside_8'],
-        'targetFileName' => 'SelectMultiplesidebyside8.rst.txt'
+        'targetFileName' => 'CodeSnippets/SelectMultiplesidebyside8.rst.txt'
     ],
 
     [
         'action' => 'createPhpArrayCodeSnippet',
         'sourceFile' => 'typo3conf/ext/styleguide/Configuration/TCA/tx_styleguide_elements_select.php',
         'fields' => ['columns/select_multiplesidebyside_10'],
-        'targetFileName' => 'SelectMultiplesidebyside10.rst.txt'
+        'targetFileName' => 'CodeSnippets/SelectMultiplesidebyside10.rst.txt'
     ],
 
     [
         'action' => 'createPhpArrayCodeSnippet',
         'sourceFile' => 'typo3conf/ext/styleguide/Configuration/TCA/tx_styleguide_elements_select.php',
         'fields' => ['columns/select_single_1'],
-        'targetFileName' => 'SelectSingle1.rst.txt'
+        'targetFileName' => 'CodeSnippets/SelectSingle1.rst.txt'
     ],
 
     [
         'action' => 'createPhpArrayCodeSnippet',
         'sourceFile' => 'typo3conf/ext/styleguide/Configuration/TCA/tx_styleguide_elements_select.php',
         'fields' => ['columns/select_single_3'],
-        'targetFileName' => 'SelectSingle3.rst.txt'
+        'targetFileName' => 'CodeSnippets/SelectSingle3.rst.txt'
     ],
 
     [
         'action' => 'createPhpArrayCodeSnippet',
         'sourceFile' => 'typo3conf/ext/styleguide/Configuration/TCA/tx_styleguide_elements_select.php',
         'fields' => ['columns/select_single_4'],
-        'targetFileName' => 'SelectSingle4.rst.txt'
+        'targetFileName' => 'CodeSnippets/SelectSingle4.rst.txt'
     ],
 
     [
         'action' => 'createPhpArrayCodeSnippet',
         'sourceFile' => 'typo3conf/ext/styleguide/Configuration/TCA/tx_styleguide_elements_select.php',
         'fields' => ['columns/select_single_7'],
-        'targetFileName' => 'SelectSingle7.rst.txt'
+        'targetFileName' => 'CodeSnippets/SelectSingle7.rst.txt'
     ],
     [
         'action' => 'createPhpArrayCodeSnippet',
         'sourceFile' => 'typo3conf/ext/styleguide/Configuration/TCA/tx_styleguide_elements_select.php',
         'fields' => ['columns/select_single_8'],
-        'targetFileName' => 'SelectSingle8.rst.txt'
+        'targetFileName' => 'CodeSnippets/SelectSingle8.rst.txt'
     ],
 
     [
         'action' => 'createPhpArrayCodeSnippet',
         'sourceFile' => 'typo3conf/ext/styleguide/Configuration/TCA/tx_styleguide_elements_select.php',
         'fields' => ['columns/select_single_10'],
-        'targetFileName' => 'SelectSingle10.rst.txt'
+        'targetFileName' => 'CodeSnippets/SelectSingle10.rst.txt'
     ],
 
     [
         'action' => 'createPhpArrayCodeSnippet',
         'sourceFile' => 'typo3conf/ext/styleguide/Configuration/TCA/tx_styleguide_elements_select.php',
         'fields' => ['columns/select_single_12'],
-        'targetFileName' => 'SelectSingle12.rst.txt'
+        'targetFileName' => 'CodeSnippets/SelectSingle12.rst.txt'
     ],
     [
         'action' => 'createPhpArrayCodeSnippet',
         'sourceFile' => 'typo3conf/ext/styleguide/Configuration/TCA/tx_styleguide_elements_select.php',
         'fields' => ['columns/select_single_13'],
-        'targetFileName' => 'SelectSingle13.rst.txt'
+        'targetFileName' => 'CodeSnippets/SelectSingle13.rst.txt'
     ],
 
     [
         'action' => 'createPhpArrayCodeSnippet',
         'sourceFile' => 'typo3conf/ext/styleguide/Configuration/TCA/tx_styleguide_elements_select.php',
         'fields' => ['columns/select_single_15'],
-        'targetFileName' => 'SelectSingle15.rst.txt'
+        'targetFileName' => 'CodeSnippets/SelectSingle15.rst.txt'
     ],
 
     [
         'action' => 'createPhpArrayCodeSnippet',
         'sourceFile' => 'typo3conf/ext/styleguide/Configuration/TCA/tx_styleguide_elements_select.php',
         'fields' => ['columns/select_single_16'],
-        'targetFileName' => 'SelectSingle16.rst.txt'
+        'targetFileName' => 'CodeSnippets/SelectSingle16.rst.txt'
     ],
 
     [
         'action' => 'createPhpArrayCodeSnippet',
         'sourceFile' => 'typo3conf/ext/styleguide/Configuration/TCA/tx_styleguide_elements_select.php',
         'fields' => ['columns/select_single_17'],
-        'targetFileName' => 'SelectSingle17.rst.txt'
+        'targetFileName' => 'CodeSnippets/SelectSingle17.rst.txt'
     ],
 
     [
         'action' => 'createPhpArrayCodeSnippet',
         'sourceFile' => 'typo3conf/ext/styleguide/Configuration/TCA/tx_styleguide_elements_select.php',
         'fields' => ['columns/select_single_18'],
-        'targetFileName' => 'SelectSingle18.rst.txt'
+        'targetFileName' => 'CodeSnippets/SelectSingle18.rst.txt'
     ],
 
     [
         'action' => 'createPhpArrayCodeSnippet',
         'sourceFile' => 'typo3conf/ext/styleguide/Configuration/TCA/tx_styleguide_elements_select.php',
         'fields' => ['columns/select_single_19'],
-        'targetFileName' => 'SelectSingle19.rst.txt'
+        'targetFileName' => 'CodeSnippets/SelectSingle19.rst.txt'
     ],
 
     [
         'action' => 'createPhpArrayCodeSnippet',
         'sourceFile' => 'typo3conf/ext/styleguide/Configuration/TCA/tx_styleguide_elements_select.php',
         'fields' => ['columns/select_single_20'],
-        'targetFileName' => 'SelectSingle20.rst.txt'
+        'targetFileName' => 'CodeSnippets/SelectSingle20.rst.txt'
     ],
 
     [
         'action' => 'createPhpArrayCodeSnippet',
         'sourceFile' => 'typo3conf/ext/styleguide/Configuration/TCA/tx_styleguide_elements_select.php',
         'fields' => ['columns/select_singlebox_1'],
-        'targetFileName' => 'SelectSinglebox1.rst.txt'
+        'targetFileName' => 'CodeSnippets/SelectSinglebox1.rst.txt'
     ],
 
     [
         'action' => 'createPhpArrayCodeSnippet',
         'sourceFile' => 'typo3conf/ext/styleguide/Configuration/TCA/tx_styleguide_elements_select.php',
         'fields' => ['columns/select_singlebox_3'],
-        'targetFileName' => 'SelectSinglebox3.rst.txt'
+        'targetFileName' => 'CodeSnippets/SelectSinglebox3.rst.txt'
     ],
 
     [
         'action' => 'createPhpArrayCodeSnippet',
         'sourceFile' => 'typo3conf/ext/styleguide/Configuration/TCA/tx_styleguide_elements_select.php',
         'fields' => ['columns/select_tree_1'],
-        'targetFileName' => 'SelectTree1.rst.txt'
+        'targetFileName' => 'CodeSnippets/SelectTree1.rst.txt'
     ],
 
     [
         'action' => 'createPhpArrayCodeSnippet',
         'sourceFile' => 'typo3conf/ext/styleguide/Configuration/TCA/tx_styleguide_elements_select.php',
         'fields' => ['columns/select_tree_2'],
-        'targetFileName' => 'SelectTree2.rst.txt'
+        'targetFileName' => 'CodeSnippets/SelectTree2.rst.txt'
     ],
 
     [
         'action' => 'createPhpArrayCodeSnippet',
         'sourceFile' => 'typo3conf/ext/styleguide/Configuration/TCA/tx_styleguide_elements_select.php',
         'fields' => ['columns/select_tree_6'],
-        'targetFileName' => 'SelectTree6.rst.txt'
+        'targetFileName' => 'CodeSnippets/SelectTree6.rst.txt'
     ],
 
     [
         'action' => 'createPhpArrayCodeSnippet',
         'sourceFile' => 'typo3conf/ext/styleguide/Configuration/TCA/tx_styleguide_elements_select.php',
         'fields' => ['columns/select_requestUpdate_1'],
-        'targetFileName' => 'SelectRequestupdate1.rst.txt'
+        'targetFileName' => 'CodeSnippets/SelectRequestupdate1.rst.txt'
     ],
 
     [
         'action' => 'createPhpArrayCodeSnippet',
         'sourceFile' => 'typo3conf/ext/styleguide/Configuration/TCA/tx_styleguide_elements_rte.php',
         'fields' => ['columns/rte_1'],
-        'targetFileName' => 'Rte1.rst.txt'
+        'targetFileName' => 'CodeSnippets/Rte1.rst.txt'
     ],
 
     [
         'action' => 'createPhpArrayCodeSnippet',
         'sourceFile' => 'typo3conf/ext/styleguide/Configuration/TCA/tx_styleguide_elements_rte.php',
         'fields' => ['columns/rte_2'],
-        'targetFileName' => 'Rte2.rst.txt'
+        'targetFileName' => 'CodeSnippets/Rte2.rst.txt'
     ],
 
     [
         'action' => 'createPhpArrayCodeSnippet',
         'sourceFile' => 'typo3conf/ext/styleguide/Configuration/TCA/tx_styleguide_elements_rte.php',
         'fields' => ['columns/rte_3'],
-        'targetFileName' => 'Rte3.rst.txt'
+        'targetFileName' => 'CodeSnippets/Rte3.rst.txt'
     ],
 
     [
         'action' => 'createPhpArrayCodeSnippet',
         'sourceFile' => 'typo3conf/ext/styleguide/Configuration/TCA/tx_styleguide_elements_rte.php',
         'fields' => ['columns/rte_4'],
-        'targetFileName' => 'Rte4.rst.txt'
+        'targetFileName' => 'CodeSnippets/Rte4.rst.txt'
     ],
 
     [
         'action' => 'createPhpArrayCodeSnippet',
         'sourceFile' => 'typo3conf/ext/styleguide/Configuration/TCA/tx_styleguide_elements_rte.php',
         'fields' => ['columns/rte_5'],
-        'targetFileName' => 'Rte5.rst.txt'
+        'targetFileName' => 'CodeSnippets/Rte5.rst.txt'
     ],
 
     [
         'action' => 'createPhpArrayCodeSnippet',
         'sourceFile' => 'typo3conf/ext/styleguide/Configuration/TCA/tx_styleguide_elements_t3editor.php',
         'fields' => ['columns/t3editor_1'],
-        'targetFileName' => 'T3editor1.rst.txt'
+        'targetFileName' => 'CodeSnippets/T3editor1.rst.txt'
     ],
 
     [
         'action' => 'createPhpArrayCodeSnippet',
         'sourceFile' => 'typo3conf/ext/styleguide/Configuration/TCA/tx_styleguide_flex.php',
         'fields' => ['columns/flex_1'],
-        'targetFileName' => 'Flex1.rst.txt'
+        'targetFileName' => 'CodeSnippets/Flex1.rst.txt'
     ],
 
     [
         'action' => 'createPhpArrayCodeSnippet',
         'sourceFile' => 'typo3conf/ext/styleguide/Configuration/TCA/tx_styleguide_flex.php',
         'fields' => ['columns/flex_2'],
-        'targetFileName' => 'Flex2.rst.txt'
+        'targetFileName' => 'CodeSnippets/Flex2.rst.txt'
     ],
 
     [
         'action' => 'createPhpArrayCodeSnippet',
         'sourceFile' => 'typo3conf/ext/styleguide/Configuration/TCA/tx_styleguide_flex.php',
         'fields' => ['columns/flex_file_1'],
-        'targetFileName' => 'FlexFile1.rst.txt'
+        'targetFileName' => 'CodeSnippets/FlexFile1.rst.txt'
     ],
 
     [
         'action' => 'createPhpArrayCodeSnippet',
         'sourceFile' => 'typo3conf/ext/styleguide/Configuration/TCA/tx_styleguide_elements_slugs.php',
         'fields' => ['columns/slug_1'],
-        'targetFileName' => 'Slug1.rst.txt'
+        'targetFileName' => 'CodeSnippets/Slug1.rst.txt'
     ],
 
     [
         'action' => 'createPhpArrayCodeSnippet',
         'sourceFile' => 'typo3conf/ext/styleguide/Configuration/TCA/tx_styleguide_elements_slugs.php',
         'fields' => ['columns/slug_2'],
-        'targetFileName' => 'Slug2.rst.txt'
+        'targetFileName' => 'CodeSnippets/Slug2.rst.txt'
     ],
 
     [
         'action' => 'createPhpArrayCodeSnippet',
         'sourceFile' => 'typo3conf/ext/styleguide/Configuration/TCA/tx_styleguide_elements_slugs.php',
         'fields' => ['columns/slug_3'],
-        'targetFileName' => 'Slug3.rst.txt'
+        'targetFileName' => 'CodeSnippets/Slug3.rst.txt'
     ],
 
     [
         'action' => 'createPhpArrayCodeSnippet',
         'sourceFile' => 'typo3conf/ext/styleguide/Configuration/TCA/tx_styleguide_elements_slugs.php',
         'fields' => ['columns/slug_4'],
-        'targetFileName' => 'Slug4.rst.txt'
+        'targetFileName' => 'CodeSnippets/Slug4.rst.txt'
     ],
 
     [
         'action' => 'createPhpArrayCodeSnippet',
         'sourceFile' => 'typo3conf/ext/styleguide/Configuration/TCA/tx_styleguide_elements_slugs.php',
         'fields' => ['columns/slug_5'],
-        'targetFileName' => 'Slug5.rst.txt'
+        'targetFileName' => 'CodeSnippets/Slug5.rst.txt'
     ],
 
     [
         'action' => 'createPhpArrayCodeSnippet',
         'sourceFile' => 'typo3conf/ext/styleguide/Configuration/TCA/tx_styleguide_elements_group.php',
         'fields' => ['columns/group_db_1'],
-        'targetFileName' => 'GroupDb1.rst.txt'
+        'targetFileName' => 'CodeSnippets/GroupDb1.rst.txt'
     ],
 
     [
         'action' => 'createPhpArrayCodeSnippet',
         'sourceFile' => 'typo3conf/ext/styleguide/Configuration/TCA/tx_styleguide_elements_group.php',
         'fields' => ['columns/group_db_3'],
-        'targetFileName' => 'GroupDb3.rst.txt'
+        'targetFileName' => 'CodeSnippets/GroupDb3.rst.txt'
     ],
 
     [
         'action' => 'createPhpArrayCodeSnippet',
         'sourceFile' => 'typo3conf/ext/styleguide/Configuration/TCA/tx_styleguide_elements_group.php',
         'fields' => ['columns/group_db_8'],
-        'targetFileName' => 'GroupDb8.rst.txt'
+        'targetFileName' => 'CodeSnippets/GroupDb8.rst.txt'
     ],
 
     [
         'action' => 'createPhpArrayCodeSnippet',
         'sourceFile' => 'typo3conf/ext/styleguide/Configuration/TCA/tx_styleguide_elements_group.php',
         'fields' => ['columns/group_db_10'],
-        'targetFileName' => 'GroupDb10.rst.txt'
+        'targetFileName' => 'CodeSnippets/GroupDb10.rst.txt'
     ],
 
     [
         'action' => 'createPhpArrayCodeSnippet',
         'sourceFile' => 'typo3conf/ext/styleguide/Configuration/TCA/tx_styleguide_elements_group.php',
         'fields' => ['columns/group_db_11'],
-        'targetFileName' => 'GroupDb11.rst.txt'
+        'targetFileName' => 'CodeSnippets/GroupDb11.rst.txt'
     ],
 
     [
         'action' => 'createPhpArrayCodeSnippet',
         'sourceFile' => 'typo3conf/ext/styleguide/Configuration/TCA/tx_styleguide_elements_group.php',
         'fields' => ['columns/group_folder_1'],
-        'targetFileName' => 'GroupFolder1.rst.txt'
+        'targetFileName' => 'CodeSnippets/GroupFolder1.rst.txt'
     ],
 
     [
         'action' => 'createPhpArrayCodeSnippet',
         'sourceFile' => 'typo3conf/ext/styleguide/Configuration/TCA/tx_styleguide_inline_1n.php',
         'fields' => ['columns/inline_1'],
-        'targetFileName' => 'Inline1nInline1.rst.txt'
+        'targetFileName' => 'CodeSnippets/Inline1nInline1.rst.txt'
     ],
 
     [
         'action' => 'createPhpArrayCodeSnippet',
         'sourceFile' => 'typo3conf/ext/styleguide/Configuration/TCA/tx_styleguide_inline_1n1n.php',
         'fields' => ['columns/inline_1'],
-        'targetFileName' => 'Inline1n1nInline1.rst.txt'
+        'targetFileName' => 'CodeSnippets/Inline1n1nInline1.rst.txt'
     ],
 
     [
         'action' => 'createPhpArrayCodeSnippet',
         'sourceFile' => 'typo3conf/ext/styleguide/Configuration/TCA/tx_styleguide_inline_mm.php',
         'fields' => ['columns/inline_1'],
-        'targetFileName' => 'InlineMmInline1.rst.txt'
+        'targetFileName' => 'CodeSnippets/InlineMmInline1.rst.txt'
     ],
 
     [
         'action' => 'createPhpArrayCodeSnippet',
         'sourceFile' => 'typo3conf/ext/styleguide/Configuration/TCA/tx_styleguide_inline_mm_child.php',
         'fields' => ['columns/parents'],
-        'targetFileName' => 'InlineMmChildParents.rst.txt'
+        'targetFileName' => 'CodeSnippets/InlineMmChildParents.rst.txt'
     ],
 
     [
         'action' => 'createPhpArrayCodeSnippet',
         'sourceFile' => 'typo3conf/ext/styleguide/Configuration/TCA/tx_styleguide_inline_mn.php',
         'fields' => ['columns/inline_1'],
-        'targetFileName' => 'InlineMnInline1.rst.txt'
+        'targetFileName' => 'CodeSnippets/InlineMnInline1.rst.txt'
     ],
 
     [
         'action' => 'createPhpArrayCodeSnippet',
         'sourceFile' => 'typo3conf/ext/styleguide/Configuration/TCA/tx_styleguide_inline_mn_child.php',
         'fields' => ['columns/parents'],
-        'targetFileName' => 'InlineMnChildParents.rst.txt'
+        'targetFileName' => 'CodeSnippets/InlineMnChildParents.rst.txt'
     ],
 
     [
         'action' => 'createPhpArrayCodeSnippet',
         'sourceFile' => 'typo3conf/ext/styleguide/Configuration/TCA/tx_styleguide_inline_mnsymmetric.php',
         'fields' => ['columns/branches'],
-        'targetFileName' => 'InlineMnSymmetricBranches.rst.txt'
+        'targetFileName' => 'CodeSnippets/InlineMnSymmetricBranches.rst.txt'
     ],
 
     [
         'action' => 'createPhpArrayCodeSnippet',
         'sourceFile' => 'typo3conf/ext/styleguide/Configuration/TCA/tx_styleguide_inline_usecombination.php',
         'fields' => ['columns/inline_1'],
-        'targetFileName' => 'InlineUsecombinationcInline1.rst.txt'
+        'targetFileName' => 'CodeSnippets/InlineUsecombinationcInline1.rst.txt'
     ],
 
     [
         'action' => 'createPhpArrayCodeSnippet',
         'sourceFile' => 'typo3conf/ext/styleguide/Configuration/TCA/tx_styleguide_type.php',
         'fields' => ['columns/record_type'],
-        'targetFileName' => 'RecordType.rst.txt'
+        'targetFileName' => 'CodeSnippets/RecordType.rst.txt'
     ],
     [
         'action' => 'createPhpArrayCodeSnippet',
         'sourceFile' => 'typo3conf/ext/styleguide/Configuration/TCA/tx_styleguide_type.php',
         'fields' => ['ctrl'],
-        'targetFileName' => 'CtrlTypeCtrl.rst.txt'
+        'targetFileName' => 'CodeSnippets/CtrlTypeCtrl.rst.txt'
     ],
     [
         'action' => 'createPhpArrayCodeSnippet',
         'sourceFile' => 'typo3conf/ext/styleguide/Configuration/TCA/tx_styleguide_type.php',
         'fields' => ['types'],
-        'targetFileName' => 'CtrlTypeTypes.rst.txt'
+        'targetFileName' => 'CodeSnippets/CtrlTypeTypes.rst.txt'
     ],
 
     [
         'action' => 'createPhpArrayCodeSnippet',
         'sourceFile' => 'typo3conf/ext/styleguide/Configuration/TCA/tx_styleguide_typeforeign.php',
         'fields' => ['columns/foreign_table'],
-        'targetFileName' => 'TypeForeignForeignTable.rst.txt'
+        'targetFileName' => 'CodeSnippets/TypeForeignForeignTable.rst.txt'
     ],
     [
         'action' => 'createPhpArrayCodeSnippet',
         'sourceFile' => 'typo3conf/ext/styleguide/Configuration/TCA/tx_styleguide_typeforeign.php',
         'fields' => ['ctrl'],
-        'targetFileName' => 'TypeForeignTableCtrl.rst.txt'
+        'targetFileName' => 'CodeSnippets/TypeForeignTableCtrl.rst.txt'
     ],
 
     [
         'action' => 'createPhpArrayCodeSnippet',
         'sourceFile' => 'typo3conf/ext/styleguide/Configuration/TCA/tx_styleguide_ctrl_common.php',
         'fields' => ['ctrl'],
-        'targetFileName' => 'TxStyleguideCtrlCommon.rst.txt'
+        'targetFileName' => 'CodeSnippets/TxStyleguideCtrlCommon.rst.txt'
     ],
 
     [
         'action' => 'createPhpArrayCodeSnippet',
         'sourceFile' => 'typo3conf/ext/styleguide/Configuration/TCA/tx_styleguide_ctrl_minimal.php',
         'fields' => ['types'],
-        'targetFileName' => 'TypeMinimal.rst.txt'
+        'targetFileName' => 'CodeSnippets/TypeMinimal.rst.txt'
     ],
     [
         'action' => 'createPhpArrayCodeSnippet',
         'sourceFile' => 'typo3conf/ext/styleguide/Configuration/TCA/tx_styleguide_ctrl_minimal.php',
-        'targetFileName' => 'TxStyleguideCtrlMinimal.rst.txt'
+        'targetFileName' => 'CodeSnippets/TxStyleguideCtrlMinimal.rst.txt'
     ],
 
     [
         'action' => 'createPhpArrayCodeSnippet',
         'sourceFile' => 'typo3conf/ext/styleguide/Configuration/TCA/tx_styleguide_palette.php',
         'fields' => ['palettes'],
-        'targetFileName' => 'Palettes.rst.txt'
+        'targetFileName' => 'CodeSnippets/Palettes.rst.txt'
     ],
     [
         'action' => 'createPhpArrayCodeSnippet',
         'sourceFile' => 'typo3conf/ext/styleguide/Configuration/TCA/tx_styleguide_palette.php',
         'fields' => ['palettes/palette_1'],
-        'targetFileName' => 'PaletteDescription.rst.txt'
+        'targetFileName' => 'CodeSnippets/PaletteDescription.rst.txt'
     ],
     [
         'action' => 'createPhpArrayCodeSnippet',
         'sourceFile' => 'typo3conf/ext/styleguide/Configuration/TCA/tx_styleguide_palette.php',
         'fields' => ['types'],
-        'targetFileName' => 'PalettesTypes.rst.txt'
+        'targetFileName' => 'CodeSnippets/PalettesTypes.rst.txt'
     ],
     [
-        'action'=> 'createCodeSnippet',
-        'sourceFile'=> 'typo3conf/ext/styleguide/Classes/UserFunctions/FormEngine/SelectItemSorter.php',
-        'targetFileName'=> 'SelectItemSorter.rst.txt'
-    ],
-
-    [
-        'action'=> 'createCodeSnippet',
-        'sourceFile'=> 'typo3conf/ext/styleguide/Configuration/FlexForms/Simple.xml',
-        'targetFileName'=> 'FlexFormFile1.rst.txt'
+        'action' => 'createCodeSnippet',
+        'sourceFile' => 'typo3conf/ext/styleguide/Classes/UserFunctions/FormEngine/SelectItemSorter.php',
+        'targetFileName' => 'CodeSnippets/SelectItemSorter.rst.txt'
     ],
 
     [
-        'action'=> 'createCodeSnippet',
-        'sourceFile'=> 'typo3conf/ext/styleguide/Classes/UserFunctions/FormEngine/SlugPrefix.php',
-        'targetFileName'=> 'SlugPrefix.rst.txt'
+        'action' => 'createCodeSnippet',
+        'sourceFile' => 'typo3conf/ext/styleguide/Configuration/FlexForms/Simple.xml',
+        'targetFileName' => 'CodeSnippets/FlexFormFile1.rst.txt'
+    ],
+
+    [
+        'action' => 'createCodeSnippet',
+        'sourceFile' => 'typo3conf/ext/styleguide/Classes/UserFunctions/FormEngine/SlugPrefix.php',
+        'targetFileName' => 'CodeSnippets/SlugPrefix.rst.txt'
     ],
 ];

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,8 @@
       "typo3/cms-composer-installers": true,
       "typo3/class-alias-loader": true
     },
+    "bin-dir": ".Build/bin",
+    "sort-packages": true,
     "vendor-dir": ".Build/vendor"
   },
   "require-dev": {
@@ -61,5 +63,13 @@
     "typo3/cms-workspaces": "^11.5",
     "t3docs/examples": "11.5.x-dev",
     "t3docs/site-package": "^11.5"
+  },
+  "scripts": {
+    "generate": [
+      "@generate:codesnippets"
+    ],
+    "generate:codesnippets": [
+      ".Build/bin/typo3 codesnippet:create Documentation/"
+    ]
   }
 }


### PR DESCRIPTION
In the Documentation Folder so we can place generated files anywhere not just in this context

Introduce composer scripts for codesnippet generation, move bin to .Build, sort packages

Update all codesnippets - no updates needed

references #670