### PR TITLE
[DEPRECATION] #99523 - Deprecate type="none" pass_content

### DIFF
--- a/Documentation/ColumnsConfig/Type/None/Properties/PassContent.rst
+++ b/Documentation/ColumnsConfig/Type/None/Properties/PassContent.rst
@@ -5,6 +5,11 @@
 pass\_content
 =============
 
+..  deprecated:: 12.2
+    Instances with field configs for :php:`type="none"` having key
+    :php:`pass_content` will trigger a deprecation warning during TCA cache
+    warmup. The option will be removed with TYPO3 v13.
+
 .. confval:: pass_content (type => none)
 
    :Path: $GLOBALS['TCA'][$table]['columns'][$field]['config']


### PR DESCRIPTION
Resolves: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/310
Releases: main