### PR TITLE
Add important note about custom formengine elements

### DIFF
--- a/Documentation/ColumnsConfig/Type/User/Index.rst
+++ b/Documentation/ColumnsConfig/Type/User/Index.rst
@@ -105,6 +105,12 @@ implementing a rendering. See :ref:`FormEngine docs
     attributes :html:`name` and :html:`data-formengine-input-name` with the
     correct name, as provided in the :php:`itemFormElName`.
 
+    ..  note:: 
+        The returned data in :php:`$resultArray['html']` must be valid HTML.
+        Invalid HTML (e.g. not closed elements) may result in unexpected 
+        behaviour in TYPO3 (e.g. new inline elements not saved).
+
+
 The field would then look like this in the backend:
 
 ..  include:: /Images/Rst/ExtendingTcaFeUsers.rst.txt


### PR DESCRIPTION
Added a note, that custom formengine elements must contain valid HTML, since unexpected problems may occur if not.

Details: https://forge.typo3.org/issues/100943