### PR TITLE
[BUGFIX] Correct examples for $GLOBALS['TCA'][$table]['ctrl']['security']

### DIFF
--- a/Documentation/Ctrl/Properties/Security.rst
+++ b/Documentation/Ctrl/Properties/Security.rst
@@ -16,13 +16,15 @@ security
     :Scope: Display
 
 
-    Array of sub-properties. This is used in the Core for the :sql:`sys_file` table:
+    Array of sub-properties. This is used, for example, in the Core for the
+    :sql:`sys_file` table:
 
     ..  code-block:: php
         :caption: EXT:core/Configuration/TCA/sys_file.php
 
-        $GLOBALS['TCA']['sys_file'] = [
+        return [
             'ctrl' => [
+                // ...
                 'security' => [
                     'ignoreWebMountRestriction' => true,
                     'ignoreRootLevelRestriction' => true,
@@ -36,8 +38,9 @@ security
     ..  code-block:: php
         :caption: EXT:sys_note/Configuration/TCA/sys_note.php
 
-        $GLOBALS['TCA']['sys_note'] = [
+        return [
             'ctrl' => [
+                // ...
                 'security' => [
                     'ignorePageTypeRestriction' => true,
                 ],
@@ -45,6 +48,14 @@ security
             ],
         ];
 
+    You can also use it in an override file:
+
+    ..  code-block:: php
+        :caption: EXT:my_extension/Configuration/TCA/Overrides/my_table.php
+
+        $GLOBALS['TCA']['my_table']['ctrl']['security']['ignoreWebMountRestriction'] = true;
+        $GLOBALS['TCA']['my_table']['ctrl']['security']['ignoreRootLevelRestriction'] = true;
+        $GLOBALS['TCA']['my_table']['ctrl']['security']['ignorePageTypeRestriction'] = true;
 
     ignoreWebMountRestriction
         Allows users to access records that are not in their defined web-mount,


### PR DESCRIPTION
The Configuration/TCA/table.php files return an array with the TCA definition. Therefore, the examples should reflect this.

Releases: main, 12.4, 11.5