### PR TITLE
[TASK] Remove sentence about "cols" property in "none" type

### DIFF
--- a/Documentation/ColumnsConfig/Type/None/Properties/Size.rst
+++ b/Documentation/ColumnsConfig/Type/None/Properties/Size.rst
@@ -11,14 +11,11 @@ size
    :type: integer
    :Scope: Display
 
-   The :ref:`cols <columns-none-properties-cols>` value is used to set the width of the field,
-   and if :code:`cols` is not found, then this value is used.
-
    Value for the width of the :code:`<input>` field. To set the input field to the full width of
    the form area, use the value 50. Default is 30.
 
 
-.. deprecated:: 12.0
+.. versionchanged:: 12.0
    The TCA type `none` had two option keys for the same functionality: `cols` and
    `size`. In order to simplify the available configuration, `cols` has been
    dropped in favour of `size`.


### PR DESCRIPTION
The cols property was removed with v12.0. Therefore, the sentence does not make sense anymore. It is removed.

Additionally, the directive was changed to "versionchanged" as the cols property was really removed and not only deprecated.

See also: https://review.typo3.org/c/Packages/TYPO3.CMS/+/73816/2/typo3/sysext/backend/Classes/Form/Element/NoneElement.php

This also removes the warning while rendering:
./Documentation/ColumnsConfig/Type/None/Properties/Size.rst:14: WARNING: undefined label: columns-none-properties-cols

Releases: main, 12.4