### PR TITLE
[TASK] Adjust note in format property of datetime type

### DIFF
--- a/Documentation/ColumnsConfig/Type/Datetime/Properties/Format.rst
+++ b/Documentation/ColumnsConfig/Type/Datetime/Properties/Format.rst
@@ -1,23 +1,23 @@
-.. include:: /Includes.rst.txt
-.. _columns-input-properties-format:
-.. _columns-datetime-properties-format:
+..  include:: /Includes.rst.txt
+..  _columns-input-properties-format:
+..  _columns-datetime-properties-format:
 
 ======
 format
 ======
 
-.. confval:: format (type => datetime)
+..  confval:: format (type => datetime)
 
-   :Path: $GLOBALS['TCA'][$table]['columns'][$field]['config']
-   :type: string (keyword)
-   :Scope: Display
+    :Path: $GLOBALS['TCA'][$table]['columns'][$field]['config']
+    :type: string (keyword)
+    :Scope: Display
 
-   Sets the output format if the field is set to read-only. Read-only fields
-   with :code:`format` set to "date" will be formatted as "date", "datetime"
-   as "datetime" and "time" as "time".
+    Sets the output format if the field is set to read-only. Read-only fields
+    with :code:`format` set to "date" will be formatted as "date", "datetime"
+    as "datetime" and "time" as "time".
 
-   .. note::
-
-      The :php:`format` option defines only the display of the field value.
-      The storage format is defined via :confval:`dbType`
-      or :ref:`eval=int <columns-datetime-properties-eval>`.
+    ..  note::
+        The :php:`format` option defines how the field value will be displayed,
+        for example, in FormEngine. The storage format is defined via
+        :ref:`dbType <columns-datetime-properties-dbtype>` and falls back to
+        `eval=integer`.


### PR DESCRIPTION
See second note in the changelog:
https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/12.0/Feature-97232-NewTCATypeDatetime.html

This also removes the rendering warning:
./Documentation/ColumnsConfig/Type/Datetime/Properties/Format.rst:21: WARNING: undefined label: columns-datetime-properties-eval

Releases: main, 12.4