### PR TITLE
[TASK] Resolve rendering warnings

### DIFF
--- a/Documentation/ColumnsConfig/CommonProperties/Mm.rst
+++ b/Documentation/ColumnsConfig/CommonProperties/Mm.rst
@@ -117,9 +117,8 @@ Related configurations
 
       {#uid_local} = ###THIS_UID###
 
-   The above example uses the special field quoting syntax :php:`{#...}` around identifiers of the
-   :ref:`QueryHelper <t3coreapi:database-query-helper-quoteDatabaseIdentifiers>` to be as DBAL compatible
-   as possible.
+   The above example uses the special field quoting syntax :php:`{#...}` around
+   identifiers to be as :ref:`DBAL <t3coreapi:database>`-compatible as possible.
 
 .. _tca_property_MM_auto_creation_mm_table:
 

--- a/Documentation/ColumnsConfig/CommonProperties/Search.rst
+++ b/Documentation/ColumnsConfig/CommonProperties/Search.rst
@@ -50,6 +50,6 @@ search
       This means that the "bodytext" field of the "tt\_content" table will be searched in only for elements
       of type Text and Text & Images. This helps making any search more relevant.
 
-      The above example uses the special field quoting syntax :php:`{#...}` around identifiers of the
-      :ref:`QueryHelper <t3coreapi:database-query-helper-quoteDatabaseIdentifiers>` to be as DBAL compatible
-      as possible.
+      The above example uses the special field quoting syntax :php:`{#...}`
+      around identifiers to be as :ref:`DBAL <t3coreapi:database>`-compatible as
+      possible.

--- a/Documentation/ColumnsConfig/Type/File/Properties/Appearance.rst
+++ b/Documentation/ColumnsConfig/Type/File/Properties/Appearance.rst
@@ -26,11 +26,13 @@ appearance
 
     addMediaLinkTitle (string or LLL reference)
         ..  versionadded:: 12.3
+
         Overrides the link text and title of the "Add media by URL" button
         with a localized string. Only useful, if the element browser is enabled.
 
     uploadFilesLinkTitle (string or LLL reference)
         ..  versionadded:: 12.3
+
         Overrides the link text and title of the "Select & upload files" button
         with a localized string. Only useful, if the element browser is enabled.
 

--- a/Documentation/ColumnsConfig/Type/Group/Properties/Mm.rst
+++ b/Documentation/ColumnsConfig/Type/Group/Properties/Mm.rst
@@ -136,8 +136,7 @@ Related configurations
 
       {#uid_local} = ###THIS_UID###
 
-   The above example uses the special field quoting syntax :php:`{#...}` around identifiers of the
-   :ref:`QueryHelper <t3coreapi:database-query-helper-quoteDatabaseIdentifiers>` to be as DBAL compatible
-   as possible.
+   The above example uses the special field quoting syntax :php:`{#...}` around
+   identifiers to be as :ref:`DBAL <t3coreapi:database>`-compatible as possible.
 
 .. todo: add Examples

--- a/Documentation/ColumnsConfig/Type/Select/Properties/ForeignTableWhere.rst
+++ b/Documentation/ColumnsConfig/Type/Select/Properties/ForeignTableWhere.rst
@@ -18,10 +18,9 @@ foreign_table_where
 Field quoting
 =============
 
-The example below uses the special field quoting syntax :php:`{#...}`
-around identifiers of the
-:ref:`QueryHelper <t3coreapi:database-query-helper-quoteDatabaseIdentifiers>`
-to be as DBAL compatible as possible. Note that :php:`ORDER BY` and :php:`GROUP BY`
+The example below uses the special field quoting syntax :php:`{#...}` around
+identifiers to be as :ref:`DBAL <t3coreapi:database>`-compatible as possible.
+Note that :php:`ORDER BY` and :php:`GROUP BY`
 should NOT be quoted, since they always receive proper quoting automatically
 through the API.
 

--- a/Documentation/ColumnsConfig/Type/Select/Properties/Mm.rst
+++ b/Documentation/ColumnsConfig/Type/Select/Properties/Mm.rst
@@ -124,6 +124,5 @@ Related configurations
 
       {#uid_local} = ###THIS_UID###
 
-   The above example uses the special field quoting syntax :php:`{#...}` around identifiers of the
-   :ref:`QueryHelper <t3coreapi:database-query-helper-quoteDatabaseIdentifiers>` to be as DBAL compatible
-   as possible.
+   The above example uses the special field quoting syntax :php:`{#...}` around
+   identifiers to be as :ref:`DBAL <t3coreapi:database>`-compatible as possible.


### PR DESCRIPTION
The referenced QueryHelper class is gone, therefore the corresponding sentences are adjusted.

This solves the following warnings:

    ./Documentation/ColumnsConfig/CommonProperties/Mm.rst:120: WARNING: undefined label: t3coreapi:database-query-helper-quotedatabaseidentifiers
    ./Documentation/ColumnsConfig/CommonProperties/Search.rst:53: WARNING: undefined label: t3coreapi:database-query-helper-quotedatabaseidentifiers
    ./Documentation/ColumnsConfig/Type/Group/Properties/Mm.rst:139: WARNING: undefined label: t3coreapi:database-query-helper-quotedatabaseidentifiers
    ./Documentation/ColumnsConfig/Type/Select/Properties/ForeignTableWhere.rst:21: WARNING: undefined label: t3coreapi:database-query-helper-quotedatabaseidentifiers
    ./Documentation/ColumnsConfig/Type/Select/Properties/Mm.rst:127: WARNING: undefined label: t3coreapi:database-query-helper-quotedatabaseidentifiers

Additionally, the following warnings are also solved:

    ./Documentation/ColumnsConfig/Type/File/Properties/Appearance.rst:29: WARNING: Explicit markup ends without a blank line; unexpected unindent.
    ./Documentation/ColumnsConfig/Type/File/Properties/Appearance.rst:34: WARNING: Explicit markup ends without a blank line; unexpected unindent.

Releases: main, 12.4