### PR TITLE
[Backport 11.5] [BUGFIX] Correct examples for $GLOBALS['TCA'][$table]['ctrl']['security'] (#712)

### DIFF
--- a/Documentation/Ctrl/Properties/Security.rst
+++ b/Documentation/Ctrl/Properties/Security.rst
@@ -1,38 +1,50 @@
-.. include:: /Includes.rst.txt
-.. _ctrl-reference-security:
-.. _ctrl-security:
-.. _ctrl-security-ignorewebmountrestriction:
-.. _ctrl-security-ignorerootlevelrestriction:
+..  include:: /Includes.rst.txt
+..  _ctrl-reference-security:
+..  _ctrl-security:
+..  _ctrl-security-ignorewebmountrestriction:
+..  _ctrl-security-ignorerootlevelrestriction:
 
 ========
 security
 ========
 
-.. confval:: security
+..  confval:: security
 
-   :Path: $GLOBALS['TCA'][$table]['ctrl']
-   :type: array
-   :Scope: Display
+    :Path: $GLOBALS['TCA'][$table]['ctrl']
+    :type: array
+    :Scope: Display
 
 
-   Array of sub-properties. This is used in the core for the "sys\_file" table:
+    Array of sub-properties. This is used, for example, in the Core for the
+    :sql:`sys_file` table:
 
-   .. code-block:: php
+    ..  code-block:: php
+        :caption: EXT:core/Configuration/TCA/sys_file.php
 
-      $GLOBALS['TCA']['sys_file'] = [
-         'ctrl' => [
-            'security' => [
-               'ignoreWebMountRestriction' => true,
-               'ignoreRootLevelRestriction' => true,
+        return [
+            'ctrl' => [
+                // ...
+                'security' => [
+                    'ignoreWebMountRestriction' => true,
+                    'ignoreRootLevelRestriction' => true,
+                ],
+                // ...
             ],
-            ...
-         ],
-      ];
+        ];
 
-   ignoreWebMountRestriction
-      Allows users to access records that are not in their defined web-mount,
-      thus bypassing this restriction.
+    You can also use it in an override file:
 
-   ignoreRootLevelRestriction
-      Allows non-admin users to access records that on the root-level (page-id 0),
-      thus bypassing this usual restriction.
+    ..  code-block:: php
+        :caption: EXT:my_extension/Configuration/TCA/Overrides/my_table.php
+
+        $GLOBALS['TCA']['my_table']['ctrl']['security']['ignoreWebMountRestriction'] = true;
+        $GLOBALS['TCA']['my_table']['ctrl']['security']['ignoreRootLevelRestriction'] = true;
+
+
+    ignoreWebMountRestriction
+        Allows users to access records that are not in their defined web-mount,
+        thus bypassing this restriction.
+
+    ignoreRootLevelRestriction
+        Allows non-admin users to access records that on the root-level (page-id 0),
+        thus bypassing this usual restriction.


### PR DESCRIPTION
The Configuration/TCA/table.php files return an array with the TCA definition. Therefore, the examples should reflect this.

Releases: main, 12.4, 11.5