### PR TITLE
[ISSUE] Add description to selectTree #664

### DIFF
--- a/Documentation/ColumnsConfig/Type/Select/Tree/Index.rst
+++ b/Documentation/ColumnsConfig/Type/Select/Tree/Index.rst
@@ -14,7 +14,8 @@ a hierarchical manner, similar to a tree. It is typically used when working
 with database tables that have a hierarchical structure. The properties  :ref:`treeConfig <columns-select-properties-treeconfig>` and
  :ref:`foreign_table <columns-select-properties-foreign-table>` are mandatory and must be provided to establish the
 connection to the relevant database table. Optionally, you can also use
-items or itemsProcFunc to pass the values, but these are not
+:ref:`items <columns-select-properties-items>` or :ref:`itemsProcFunc 
+<tca_property_itemsProcFunc>` to pass the values, but these are not
 sufficient on their own. The top-level item in the tree will always represent
 the descriptive name of the table.
 

--- a/Documentation/ColumnsConfig/Type/Select/Tree/Index.rst
+++ b/Documentation/ColumnsConfig/Type/Select/Tree/Index.rst
@@ -11,7 +11,7 @@ tree structure.
 
 A field with the :php:`selectTree` render type allows you to represent data in
 a hierarchical manner, similar to a tree. It is typically used when working
-with database tables that have a hierarchical structure. The properties  :ref:`treeConfig
+with database tables that have a hierarchical structure. The properties :ref:`treeConfig
 <columns-select-properties-treeconfig>` and
 :ref:`foreign_table <columns-select-properties-foreign-table>` are mandatory and must be provided to establish the
 connection to the relevant database table. Optionally, you can also use

--- a/Documentation/ColumnsConfig/Type/Select/Tree/Index.rst
+++ b/Documentation/ColumnsConfig/Type/Select/Tree/Index.rst
@@ -5,14 +5,32 @@
 selectTree
 ==========
 
-A field with the render type `selectTree` displays hierarchical data
-in a tree.
 
-.. include:: /Images/Rst/SelectTree1.rst.txt
+The selectTree render type is used to display hierarchical data in a
+tree structure.
+
+A field with the selectTree render type allows you to represent data in
+a hierarchical manner, similar to a tree. It is typically used when working
+with database tables that have a hierarchical structure. The field requires
+certain fields to be set in order to function properly. The treeConfig and
+foreign_table fields are mandatory and must be provided to establish the
+connection to the relevant database table. Optionally, you can also use
+items or itemsProcFunc to pass the values, but these are not
+sufficient on their own. The top-level item in the tree will always represent
+the descriptive name of the table.
+
+Regarding joining several tables, the selectTree field can handle multiple
+tables through the configuration options. By appropriately setting up the
+treeConfig and defining the relationships between the tables, you can create
+complex trees that span multiple database tables.
+
+Please note that the selectTree field only handles the presentation of
+hierarchical data in a tree structure and does not directly handle the
+database operations. The actual data retrieval and manipulation need to
+be implemented separately.
 
 .. toctree::
-   :titlesonly:
+:titlesonly:
 
-   Examples
-   Properties
-
+Examples
+Properties

--- a/Documentation/ColumnsConfig/Type/Select/Tree/Index.rst
+++ b/Documentation/ColumnsConfig/Type/Select/Tree/Index.rst
@@ -11,9 +11,8 @@ tree structure.
 
 A field with the :php:`selectTree` render type allows you to represent data in
 a hierarchical manner, similar to a tree. It is typically used when working
-with database tables that have a hierarchical structure. The field requires
-certain fields to be set in order to function properly. The treeConfig and
-foreign_table fields are mandatory and must be provided to establish the
+with database tables that have a hierarchical structure. The properties  :ref:`treeConfig <columns-select-properties-treeconfig>` and
+ :ref:`foreign_table <columns-select-properties-foreign-table>` are mandatory and must be provided to establish the
 connection to the relevant database table. Optionally, you can also use
 items or itemsProcFunc to pass the values, but these are not
 sufficient on their own. The top-level item in the tree will always represent

--- a/Documentation/ColumnsConfig/Type/Select/Tree/Index.rst
+++ b/Documentation/ColumnsConfig/Type/Select/Tree/Index.rst
@@ -29,8 +29,11 @@ hierarchical data in a tree structure and does not directly handle the
 database operations. The actual data retrieval and manipulation need to
 be implemented separately.
 
+.. include:: /Images/Rst/SelectTree1.rst.txt
+
+
 .. toctree::
-:titlesonly:
+    :titlesonly:
 
 Examples
 Properties

--- a/Documentation/ColumnsConfig/Type/Select/Tree/Index.rst
+++ b/Documentation/ColumnsConfig/Type/Select/Tree/Index.rst
@@ -6,7 +6,7 @@ selectTree
 ==========
 
 
-The selectTree render type is used to display hierarchical data in a
+The :php:`selectTree` render type is used to display hierarchical data in a
 tree structure.
 
 A field with the selectTree render type allows you to represent data in

--- a/Documentation/ColumnsConfig/Type/Select/Tree/Index.rst
+++ b/Documentation/ColumnsConfig/Type/Select/Tree/Index.rst
@@ -19,7 +19,7 @@ connection to the relevant database table. Optionally, you can also use
 sufficient on their own. The top-level item in the tree will always represent
 the descriptive name of the table.
 
-Regarding joining several tables, the selectTree field can handle multiple
+Regarding joining several tables, the :php:`selectTree` render type can handle multiple
 tables through the configuration options. By appropriately setting up the
 treeConfig and defining the relationships between the tables, you can create
 complex trees that span multiple database tables.

--- a/Documentation/ColumnsConfig/Type/Select/Tree/Index.rst
+++ b/Documentation/ColumnsConfig/Type/Select/Tree/Index.rst
@@ -9,7 +9,7 @@ selectTree
 The :php:`selectTree` render type is used to display hierarchical data in a
 tree structure.
 
-A field with the selectTree render type allows you to represent data in
+A field with the :php:`selectTree` render type allows you to represent data in
 a hierarchical manner, similar to a tree. It is typically used when working
 with database tables that have a hierarchical structure. The field requires
 certain fields to be set in order to function properly. The treeConfig and

--- a/Documentation/ColumnsConfig/Type/Select/Tree/Index.rst
+++ b/Documentation/ColumnsConfig/Type/Select/Tree/Index.rst
@@ -11,8 +11,9 @@ tree structure.
 
 A field with the :php:`selectTree` render type allows you to represent data in
 a hierarchical manner, similar to a tree. It is typically used when working
-with database tables that have a hierarchical structure. The properties  :ref:`treeConfig <columns-select-properties-treeconfig>` and
- :ref:`foreign_table <columns-select-properties-foreign-table>` are mandatory and must be provided to establish the
+with database tables that have a hierarchical structure. The properties  :ref:`treeConfig
+<columns-select-properties-treeconfig>` and
+:ref:`foreign_table <columns-select-properties-foreign-table>` are mandatory and must be provided to establish the
 connection to the relevant database table. Optionally, you can also use
 :ref:`items <columns-select-properties-items>` or :ref:`itemsProcFunc 
 <tca_property_itemsProcFunc>` to pass the values, but these are not
@@ -20,14 +21,7 @@ sufficient on their own. The top-level item in the tree will always represent
 the descriptive name of the table.
 
 Regarding joining several tables, the :php:`selectTree` render type can handle multiple
-tables through the configuration options. By appropriately setting up the
-treeConfig and defining the relationships between the tables, you can create
-complex trees that span multiple database tables.
-
-Please note that the selectTree field only handles the presentation of
-hierarchical data in a tree structure and does not directly handle the
-database operations. The actual data retrieval and manipulation need to
-be implemented separately.
+tables through the configuration options. 
 
 .. include:: /Images/Rst/SelectTree1.rst.txt
 


### PR DESCRIPTION
[ISSUE] Add description to selectTree #664

resolves: https://github.com/TYPO3-Documentation/TYPO3CMS-Reference-TCA/issues/664

releases: main

Remark: I have written a description for the selectTree