### PR TITLE
[FIX] Correction of the translationSource and transOrigPointerField documentation

### DIFF
--- a/Documentation/Ctrl/Properties/TransOrigPointerField.rst
+++ b/Documentation/Ctrl/Properties/TransOrigPointerField.rst
@@ -23,6 +23,10 @@ transOrigPointerField
    The target field must be configured in :php:`$GLOBALS['TCA'][<table>]['columns']`,
    at least as a passthrough type.
 
+ .. note::
+      Sometimes :sql:`l18n_parent` is used for this field in Core tables. This
+      is for historic reasons.
+
 Example
 =======
 

--- a/Documentation/Ctrl/Properties/TranslationSource.rst
+++ b/Documentation/Ctrl/Properties/TranslationSource.rst
@@ -26,10 +26,6 @@ translationSource
    to French with uid 17, and the Danish translation is later created based on the French translation, then the
    Danish translation has uid 13 set as :sql:`l18n_parent` and 17 as :sql:`l10n_source`.
 
-   .. note::
-      Sometimes :sql:`l18n_parent` is used for this field in Core tables. This
-      is for historic reasons.
-
 Example
 =======
 


### PR DESCRIPTION
releases: main

Remark: I deleted the "Sometimes l18n_parent is used for this field in Core tables. This is for historic reasons." part in the translationSource documentation and pasted it into the transOrigPointerField documentation where it belongs