### PR TITLE
[FIX] Adding missing information in the TCA for the datetime formats

### DIFF
--- a/Documentation/ColumnsConfig/Type/Datetime/Properties/Format.rst
+++ b/Documentation/ColumnsConfig/Type/Datetime/Properties/Format.rst
@@ -14,7 +14,7 @@ format
 
     Sets the output format if the field is set to read-only. Read-only fields
     with :code:`format` set to "date" will be formatted as "date", "datetime"
-    as "datetime" and "time" as "time".
+    as "datetime", "time" as "time" and "timesec" as "timesec".
 
     ..  note::
         The :php:`format` option defines how the field value will be displayed,


### PR DESCRIPTION
releases: main

Remark: I added "timesec", because it was missing, even tho it was written in the Changelog: https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/12.0/Feature-97232-NewTCATypeDatetime.html