### PR TITLE
Fixed typo in ValuePicker example

### DIFF
--- a/Documentation/ColumnsConfig/Type/Number/Properties/ValuePicker.rst
+++ b/Documentation/ColumnsConfig/Type/Number/Properties/ValuePicker.rst
@@ -35,7 +35,7 @@ Example
       'label' => 'Number field',
       'config' => [
          'type' => 'number',
-         'mode' => ''
+         'mode' => '',
          'valuePicker' => [
             'items' => [
                ['One', '1'],


### PR DESCRIPTION
Fixed typo in ValuePicker example (https://docs.typo3.org/m/typo3/reference-tca/12.4/en-us/ColumnsConfig/Type/Number/Properties/ValuePicker.html)

Forgot a "," at the end of the 'mode' => '' line.