### PR TITLE
[TASK] Streamline manual links

### DIFF
--- a/Documentation/BestPractises/LanguageFields.rst
+++ b/Documentation/BestPractises/LanguageFields.rst
@@ -6,7 +6,7 @@
 Language fields
 ================
 
-See also the :ref:`Frontend Localization Guide <t3l10n:core-support-tca>`.
+See also the :ref:`Frontend Localization Guide <t3translate:core-support-tca>`.
 
 .. note::
    It is possible to change the names of the following fields, however this is

--- a/Documentation/Ctrl/Properties/LanguageField.rst
+++ b/Documentation/Ctrl/Properties/LanguageField.rst
@@ -32,7 +32,7 @@ languageField
    these languages and if this option is set, edit access for languages
    will be enforced for this table.
 
-   Also see the :ref:`Frontend Localization Guide <t3l10n:core-support-tca>`
+   Also see the :ref:`Frontend Localization Guide <t3translate:core-support-tca>`
    for a discussion about the effects of
    this property (and other TCA properties) on the localization process.
 

--- a/Documentation/Settings.cfg
+++ b/Documentation/Settings.cfg
@@ -32,7 +32,6 @@ t3-fieldcontrol-passwordgenerator =  t3-fieldcontrol-passwordgenerator // t3-fie
 
 # Official TYPO3 manuals
 h2document     = https://docs.typo3.org/m/typo3/docs-how-to-document/main/en-us/
-# t3cheatsheets  = https://docs.typo3.org/m/typo3/docs-cheatsheets/main/en-us/
 # t3contribute   = https://docs.typo3.org/m/typo3/guide-contributionworkflow/main/en-us/
 t3coreapi      = https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/
 # t3docteam      = https://docs.typo3.org/m/typo3/team-t3docteam/main/en-us/
@@ -40,11 +39,10 @@ t3coreapi      = https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/
 # t3extexample   = https://docs.typo3.org/m/typo3/guide-example-extension-manual/main/en-us/
 # t3home         = https://docs.typo3.org/
 # t3install      = https://docs.typo3.org/m/typo3/guide-installation/main/en-us/
-t3l10n         = https://docs.typo3.org/m/typo3/guide-frontendlocalization/main/en-us/
 # t3sitepackage  = https://docs.typo3.org/m/typo3/tutorial-sitepackage/main/en-us/
 # t3start        = https://docs.typo3.org/m/typo3/tutorial-getting-started/main/en-us/
 # t3tca          = https://docs.typo3.org/m/typo3/reference-tca/main/en-us/
-# t3translate    = https://docs.typo3.org/m/typo3/guide-frontendlocalization/main/en-us/
+t3translate    = https://docs.typo3.org/m/typo3/guide-frontendlocalization/main/en-us/
 t3tsconfig     = https://docs.typo3.org/m/typo3/reference-tsconfig/main/en-us/
 t3tsref        = https://docs.typo3.org/m/typo3/reference-typoscript/main/en-us/
 # t3ts45         = https://docs.typo3.org/m/typo3/tutorial-typoscript-in-45-minutes/main/en-us/
@@ -58,10 +56,18 @@ ext_core           = https://docs.typo3.org/c/typo3/cms-core/main/en-us/
 # ext_felogin        = https://docs.typo3.org/c/typo3/cms-felogin/main/en-us/
 # ext_form           = https://docs.typo3.org/c/typo3/cms-form/main/en-us/
 # ext_fsc            = https://docs.typo3.org/c/typo3/cms-fluid-styled-content/main/en-us/
+# ext_impexp         = https://docs.typo3.org/c/typo3/cms-impexp/main/en-us/
 # ext_indexed_search = https://docs.typo3.org/c/typo3/cms-indexed-search/main/en-us/
+# ext_linkvalidator  = https://docs.typo3.org/c/typo3/cms-linkvalidator/main/en-us/
+# ext_lowlevel       = https://docs.typo3.org/c/typo3/cms-lowlevel/main/en-us/
+# ext_reactions      = https://docs.typo3.org/c/typo3/cms-reactions/main/en-us/
+# ext_recycler       = https://docs.typo3.org/c/typo3/cms-recycler/main/en-us/
+# ext_redirects      = https://docs.typo3.org/c/typo3/cms-redirects/main/en-us/
+# ext_reports        = https://docs.typo3.org/c/typo3/cms-reports/main/en-us/
 # ext_rte_ckeditor   = https://docs.typo3.org/c/typo3/cms-rte-ckeditor/main/en-us/
 # ext_scheduler      = https://docs.typo3.org/c/typo3/cms-scheduler/main/en-us/
 # ext_seo            = https://docs.typo3.org/c/typo3/cms-seo/main/en-us/
+# ext_t3editor       = https://docs.typo3.org/c/typo3/cms-t3editor/main/en-us/
 ext_workspaces     = https://docs.typo3.org/c/typo3/cms-workspaces/main/en-us/
 
 [extlinks]


### PR DESCRIPTION
- Remove outdated t3cheatsheets reference
- Use t3translate instead of t3l10n like other manuals
- Add missing system extension manuals

Releases: main, 12.4