### PR TITLE
[Backport 12.4] [TASK] Streamline manual links (#758)

### DIFF
--- a/Documentation/BestPractises/LanguageFields.rst
+++ b/Documentation/BestPractises/LanguageFields.rst
@@ -6,7 +6,7 @@
 Language fields
 ================
 
-See also the :ref:`Frontend Localization Guide <t3l10n:core-support-tca>`.
+See also the :ref:`Frontend Localization Guide <t3translate:core-support-tca>`.
 
 .. note::
    It is possible to change the names of the following fields, however this is

--- a/Documentation/Ctrl/Properties/LanguageField.rst
+++ b/Documentation/Ctrl/Properties/LanguageField.rst
@@ -32,7 +32,7 @@ languageField
    these languages and if this option is set, edit access for languages
    will be enforced for this table.
 
-   Also see the :ref:`Frontend Localization Guide <t3l10n:core-support-tca>`
+   Also see the :ref:`Frontend Localization Guide <t3translate:core-support-tca>`
    for a discussion about the effects of
    this property (and other TCA properties) on the localization process.
 

--- a/Documentation/Settings.cfg
+++ b/Documentation/Settings.cfg
@@ -39,27 +39,35 @@ t3coreapi      = https://docs.typo3.org/m/typo3/reference-coreapi/12.4/en-us/
 # t3extexample   = https://docs.typo3.org/m/typo3/guide-example-extension-manual/12.4/en-us/
 # t3home         = https://docs.typo3.org/
 # t3install      = https://docs.typo3.org/m/typo3/guide-installation/12.4/en-us/
-t3l10n         = https://docs.typo3.org/m/typo3/guide-frontendlocalization/12.4/en-us/
 # t3sitepackage  = https://docs.typo3.org/m/typo3/tutorial-sitepackage/12.4/en-us/
 # t3start        = https://docs.typo3.org/m/typo3/tutorial-getting-started/12.4/en-us/
 # t3tca          = https://docs.typo3.org/m/typo3/reference-tca/12.4/en-us/
-# t3translate    = https://docs.typo3.org/m/typo3/guide-frontendlocalization/12.4/en-us/
+t3translate    = https://docs.typo3.org/m/typo3/guide-frontendlocalization/12.4/en-us/
 t3tsconfig     = https://docs.typo3.org/m/typo3/reference-tsconfig/12.4/en-us/
 t3tsref        = https://docs.typo3.org/m/typo3/reference-typoscript/12.4/en-us/
+# t3ts45         = https://docs.typo3.org/m/typo3/tutorial-typoscript-in-45-minutes/12.4/en-us/
 # t3viewhelper   = https://docs.typo3.org/other/typo3/view-helper-reference/12.4/en-us/
 # t3upgrade      = https://docs.typo3.org/m/typo3/guide-installation/12.4/en-us/
 
 # TYPO3 system extensions
 # ext_adminpanel     = https://docs.typo3.org/c/typo3/cms-adminpanel/12.4/en-us/
-ext_core           = https://docs.typo3.org/c/typo3/cms-core/12.4/en-us/
+ext_core           = https://docs.typo3.org/c/typo3/cms-core/main/en-us/
 # ext_dashboard      = https://docs.typo3.org/c/typo3/cms-dashboard/12.4/en-us/
 # ext_felogin        = https://docs.typo3.org/c/typo3/cms-felogin/12.4/en-us/
 # ext_form           = https://docs.typo3.org/c/typo3/cms-form/12.4/en-us/
 # ext_fsc            = https://docs.typo3.org/c/typo3/cms-fluid-styled-content/12.4/en-us/
+# ext_impexp         = https://docs.typo3.org/c/typo3/cms-impexp/12.4/en-us/
 # ext_indexed_search = https://docs.typo3.org/c/typo3/cms-indexed-search/12.4/en-us/
+# ext_linkvalidator  = https://docs.typo3.org/c/typo3/cms-linkvalidator/12.4/en-us/
+# ext_lowlevel       = https://docs.typo3.org/c/typo3/cms-lowlevel/12.4/en-us/
+# ext_reactions      = https://docs.typo3.org/c/typo3/cms-reactions/12.4/en-us/
+# ext_recycler       = https://docs.typo3.org/c/typo3/cms-recycler/12.4/en-us/
+# ext_redirects      = https://docs.typo3.org/c/typo3/cms-redirects/12.4/en-us/
+# ext_reports        = https://docs.typo3.org/c/typo3/cms-reports/12.4/en-us/
 # ext_rte_ckeditor   = https://docs.typo3.org/c/typo3/cms-rte-ckeditor/12.4/en-us/
 # ext_scheduler      = https://docs.typo3.org/c/typo3/cms-scheduler/12.4/en-us/
 # ext_seo            = https://docs.typo3.org/c/typo3/cms-seo/12.4/en-us/
+# ext_t3editor       = https://docs.typo3.org/c/typo3/cms-t3editor/12.4/en-us/
 ext_workspaces     = https://docs.typo3.org/c/typo3/cms-workspaces/12.4/en-us/
 
 [extlinks]


### PR DESCRIPTION
- Remove outdated t3cheatsheets reference
- Use t3translate instead of t3l10n like other manuals
- Add missing system extension manuals

Releases: main, 12.4