### PR TITLE
[BUGFIX] Fix wrong information in code snippets

### DIFF
--- a/Documentation/CodeSnippets/Checkbox17.rst.txt
+++ b/Documentation/CodeSnippets/Checkbox17.rst.txt
@@ -15,8 +15,6 @@
                    'items' => [
                        [
                            'label' => 'foo',
-                           'labelChecked' => 'Enabled',
-                           'labelUnchecked' => 'Disabled',
                        ],
                    ],
                ],

--- a/Documentation/CodeSnippets/Checkbox18.rst.txt
+++ b/Documentation/CodeSnippets/Checkbox18.rst.txt
@@ -15,8 +15,6 @@
                    'items' => [
                        [
                            'label' => 'foo',
-                           'labelChecked' => 'Enabled',
-                           'labelUnchecked' => 'Disabled',
                            'invertStateDisplay' => true,
                        ],
                    ],


### PR DESCRIPTION
The settings `labelChecked` and `labelUnchecked` are only used with render type `checkboxLabeledToggle` and misleading here.

See core for reference:
https://github.com/TYPO3/typo3/blob/main/typo3/sysext/backend/Classes/Form/FormDataProvider/TcaCheckboxItems.php#L86

The error exists also in older versions of the documentation. If desired, I can also create patches for these versions.