### PR TITLE
[PREPORT] Ctrl has two main categories, but mentioned three 

### DIFF
--- a/Documentation/Introduction/Index.rst
+++ b/Documentation/Introduction/Index.rst
@@ -153,7 +153,7 @@ These are basically divided in two main categories:
   can only be edited by admin-users, may only exist in the tree root
   etc.
 
-- For all tables configured in :php:`$GLOBALS['TCA']` this section must exist.
+For all tables configured in :php:`$GLOBALS['TCA']` this section must exist.
 
 :ref:`Full reference <ctrl>`
 


### PR DESCRIPTION
Preport of #769

Ctrl has two main categories. mentioned three - Update Index.rst

It is confusing for the reader to see three points after mentioning that there are two main categories