### PR TITLE
[FEATURE] #101653 - Auto-create DB fields from TCA columns for type "check"

### DIFF
--- a/Documentation/ColumnsConfig/Type/Check/Index.rst
+++ b/Documentation/ColumnsConfig/Type/Check/Index.rst
@@ -6,6 +6,12 @@
 Checkboxes
 ==========
 
+..  versionadded:: 13.0
+    When using the `check` type, TYPO3 takes care of
+    :ref:`generating the according database field <t3coreapi:auto-generated-db-structure>`.
+    A developer does not need to define this field in an extension's
+    :file:`ext_tables.sql` file.
+
 
 Introduction
 ============


### PR DESCRIPTION
Related: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/647
Releases: main