### PR TITLE
[TASK] Move note about auto-generated slug db field

### DIFF
--- a/Documentation/ColumnsConfig/Type/Slug/Examples.rst
+++ b/Documentation/ColumnsConfig/Type/Slug/Examples.rst
@@ -5,11 +5,6 @@
 Examples
 ========
 
-..  versionadded:: 12.0
-    When using the `slug` type, TYPO3 takes care of generating the according
-    database field. A developer does not need to define this field in an
-    extension's :file:`ext_tables.sql` file.
-
 ..  _tca_example_slug_1:
 
 Slug field

--- a/Documentation/ColumnsConfig/Type/Slug/Index.rst
+++ b/Documentation/ColumnsConfig/Type/Slug/Index.rst
@@ -6,6 +6,12 @@
 Slugs / URL parts
 =================
 
+..  versionadded:: 12.0
+    When using the `slug` type, TYPO3 takes care of
+    :ref:`generating the according database field <t3coreapi:auto-generated-db-structure>`.
+    A developer does not need to define this field in an extension's
+    :file:`ext_tables.sql` file.
+
 The main purpose of this type is to define parts of a URL path to generate and
 resolve URLs.
 


### PR DESCRIPTION
The note is moved to the start page of the type to be consistent with the other types (which have sometimes no example page). Additionally, a link to more information about this in TYPO3 Explained is added.

Releases: main, 12.4