### PR TITLE
[FEATURE] #101890 - Auto-create DB fields from TCA columns for type "imageManipulation"

### DIFF
--- a/Documentation/ColumnsConfig/Type/ImageManipulation/Index.rst
+++ b/Documentation/ColumnsConfig/Type/ImageManipulation/Index.rst
@@ -6,6 +6,12 @@
 Image manipulation
 ==================
 
+..  versionadded:: 13.0
+    When using the `imageManipulation` type, TYPO3 takes care of
+    :ref:`generating the according database field <t3coreapi:auto-generated-db-structure>`.
+    A developer does not need to define this field in an extension's
+    :file:`ext_tables.sql` file.
+
 The type "imageManipulation" generates a button showing an image cropper in the backend for image files.
 It is typically only used in FAL relations. The crop information is stored as an JSON array into the field.
 


### PR DESCRIPTION
Related: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/652
Releases: main