### PR TITLE
[FEATURE] #101915 - Auto-create DB fields from TCA columns for type "language"

### DIFF
--- a/Documentation/ColumnsConfig/Type/Language/Index.rst
+++ b/Documentation/ColumnsConfig/Type/Language/Index.rst
@@ -9,6 +9,12 @@ Language fields
 .. versionadded:: 11.2
    The TCA field type called `language` has been added to TYPO3 Core.
 
+..  versionadded:: 13.0
+    When using the `language` type, TYPO3 takes care of
+    :ref:`generating the according database field <t3coreapi:auto-generated-db-structure>`.
+    A developer does not need to define this field in an extension's
+    :file:`ext_tables.sql` file.
+
 This field type displays all languages available in the current site context.
 Outside of the site context it displays all languages available in the
 installation.


### PR DESCRIPTION
Related: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/655
Releases: main