### PR TITLE
[FEATURE] #101908 - Auto-create DB fields from TCA columns for type "group"

### DIFF
--- a/Documentation/ColumnsConfig/Type/Group/Index.rst
+++ b/Documentation/ColumnsConfig/Type/Group/Index.rst
@@ -11,6 +11,13 @@ Group fields
    the old combination of :php:`type => 'group'` together with
    :php:`internal_type => 'folder'`.
 
+..  versionadded:: 13.0
+    When using the `group` type, TYPO3 takes care of
+    :ref:`generating the according database field <t3coreapi:auto-generated-db-structure>`.
+    A developer does not need to define this field in an extension's
+    :file:`ext_tables.sql` file.
+
+
 The group element (:php:`type' => 'group'`) in TYPO3 makes it possible to create references from a record of one table to many records from multiple tables in the system. The foreign tables can be the table itself (thus a self-reference) or any other table.
 This is especially useful (compared to the "select" type) when records are scattered over the page tree and require
 the Element Browser to select records for adding them to the group field.


### PR DESCRIPTION
Related: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/660
Releases: main