### PR TITLE
[FEATURE] #102106 - Auto-create DB fields from TCA columns for type "password"

### DIFF
--- a/Documentation/ColumnsConfig/Type/Password/Index.rst
+++ b/Documentation/ColumnsConfig/Type/Password/Index.rst
@@ -11,6 +11,12 @@ Password
    :php:`eval=password` and :php:`eval=saltedPassword` option of
    TCA type :php:`input`.
 
+..  versionadded:: 13.0
+    When using the `password` type, TYPO3 takes care of
+    :ref:`generating the according database field <t3coreapi:auto-generated-db-structure>`.
+    A developer does not need to define this field in an extension's
+    :file:`ext_tables.sql` file.
+
 The TCA type :php:`password` should be used for input values that represent
 passwords.
 


### PR DESCRIPTION
Related: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/687
Releases: main