### PR TITLE
[Backport 11.5] [TASK] Add links on "text" TCA type page (#804)

### DIFF
--- a/Documentation/ColumnsConfig/Type/Text/Index.rst
+++ b/Documentation/ColumnsConfig/Type/Text/Index.rst
@@ -1,46 +1,52 @@
-﻿.. include:: /Includes.rst.txt
+﻿..  include:: /Includes.rst.txt
 
-.. _columns-text:
+..  _columns-text:
 
 ================
 Text areas & RTE
 ================
 
-.. contents:: Table of contents:
-   :local:
-   :depth: 1
+..  contents:: Table of contents:
+    :local:
+    :depth: 1
 
-.. _columns-text-introduction:
+..  _columns-text-introduction:
 
 Introduction
 ============
 
-The type='text' is for multi line text input, in the database :file:`ext_tables.sql` files it is typically
-set to a :code:`TEXT` column type. In the Backend, it is rendered in various shapes: It can be rendered as
-a simple :code:`<textarea>`, as a Rich Text Editor, as a code block with syntax highlighting, and others.
+The `text` type is for multi-line text input, in the database
+:file:`ext_tables.sql` files it is typically set to a :sql:`TEXT` column type.
+In the backend, it is rendered in various shapes: It can be rendered as a simple
+:html:`<textarea>`, as a :ref:`rich text editor (RTE) <t3coreapi:rte>`, as a
+code block with syntax highlighting, and others.
 
-The following renderTypes are available:
+The following :php:`renderTypes` are available:
 
-*  :ref:`default <columns-text-renderType-default>`: A simple text area
-   or a rich text field is rendered if no renderType is specified.
-*  :ref:`belayoutwizard <columns-text-renderType-belayoutwizard>`: The backend layout
-   wizard is displayed in order to edit records of table :code:`backend_layout` in the backend.
-*  :ref:`t3editor <columns-text-renderType-t3editor>`: The
-   :code:`renderType = 't3editor'`triggers a code highlighter if extension
-   `t3editor` is loaded, otherwise falls back to "default" renderType.
-*  :ref:`textTable <columns-text-renderType-textTable>`: The
-   :code:`renderType = 'textTable'` triggers a view to manage frontend table
-   display in the backend. It is used for the "Table" tt\_content content element.
+*   :ref:`default <columns-text-renderType-default>`: A simple text area
+    or a rich text field is rendered, if no renderType is specified.
+*   :ref:`belayoutwizard <columns-text-renderType-belayoutwizard>`: The backend
+    layout wizard is displayed in order to edit records of table
+    :sql:`backend_layout` in the backend.
+*   :ref:`t3editor <columns-text-renderType-t3editor>`: The
+    :php:`renderType = 't3editor'` triggers a code highlighter, if extension
+    :doc:`t3editor <ext_t3editor:Index>` is loaded, otherwise falls back to
+    the "default" renderType.
+*   :ref:`textTable <columns-text-renderType-textTable>`: The
+    :php:`renderType = 'textTable'` triggers a view to manage frontend table
+    display in the backend. It is used for the "table" :sql:`tt_content` content
+    element.
 
 
 Simple text area
 ================
 
-A simple text area or a rich text field is rendered if no renderType is specified.
+A simple text area or a rich text field is rendered, if no renderType is
+specified.
 
 ..  include:: /Images/Rst/Text4.rst.txt
 
-See :ref:`render type "default" <columns-text-renderType-default>` 
+See :ref:`render type "default" <columns-text-renderType-default>`
 on how to configure such an editor.
 
 ..  include:: /CodeSnippets/Text4.rst.txt
@@ -50,10 +56,10 @@ Rich text editor field
 
 ..  include:: /Images/Rst/Rte1.rst.txt
 
-See :ref:`property "enableRichtext" <columns-text-properties-enableRichtex>` 
+See :ref:`property "enableRichtext" <columns-text-properties-enableRichtext>`
 on how to configure such an editor.
 
-.. include:: /CodeSnippets/Rte1.rst.txt
+..  include:: /CodeSnippets/Rte1.rst.txt
 
 
 Code highlight editor
@@ -61,25 +67,27 @@ Code highlight editor
 
 ..  todo: include screenshot
 
-See :ref:`t3editor <columns-text-renderType-t3editor>` on how to configure such an editor.
+See :ref:`t3editor <columns-text-renderType-t3editor>` on how to configure such
+an editor.
 
 ..  code-block:: php
 
-    // ...
-    'type' => 'text',
-    'renderType' => 't3editor',
-    // ...
-
+    [
+        // ...
+        'type' => 'text',
+        'renderType' => 't3editor',
+        // ...
+    ]
 
 Backend layout editor
 =====================
 
-The backend layout wizard is displayed in order to edit records of table 
-:code:`backend_layout` in the backend.
+The backend layout wizard is displayed in order to edit records of table
+:sql:`backend_layout` in the backend.
 
 ..  include:: /Images/Rst/Text20.rst.txt
 
-See :ref:`render type belayoutwizard <columns-text-renderType-belayoutwizard>` 
+See :ref:`render type belayoutwizard <columns-text-renderType-belayoutwizard>`
 on how to configure such an editor.
 
 ..  include:: /CodeSnippets/Text20.rst.txt
@@ -90,7 +98,7 @@ Text field with renderType textTable
 
 ..  include:: /Images/Rst/Text17.rst.txt
 
-See :ref:`render type textTable <columns-text-renderType-textTable>` 
+See :ref:`render type textTable <columns-text-renderType-textTable>`
 on how to configure such an editor.
 
 ..  include:: /CodeSnippets/Text17.rst.txt

--- a/Documentation/Settings.cfg
+++ b/Documentation/Settings.cfg
@@ -58,4 +58,5 @@ ext_core           = https://docs.typo3.org/c/typo3/cms-core/11.5/en-us/
 # ext_rte_ckeditor   = https://docs.typo3.org/c/typo3/cms-rte-ckeditor/main/en-us/
 # ext_scheduler      = https://docs.typo3.org/c/typo3/cms-scheduler/main/en-us/
 # ext_seo            = https://docs.typo3.org/c/typo3/cms-seo/main/en-us/
+ext_t3editor       = https://docs.typo3.org/c/typo3/cms-t3editor/11.5/en-us/
 ext_workspaces     = https://docs.typo3.org/c/typo3/cms-workspaces/11.5/en-us/


### PR DESCRIPTION
Also fixes an anchor to the "property enableRichtext". Additionally, add line breaks after 80 characters.

Releases: main, 12.4, 11.5