### PR TITLE
[FEATURE] #101997 - Auto-create DB fields from TCA columns for type "flex"

### DIFF
--- a/Documentation/ColumnsConfig/Type/Flex/Index.rst
+++ b/Documentation/ColumnsConfig/Type/Flex/Index.rst
@@ -5,6 +5,12 @@
 FlexForm field
 ==============
 
+..  versionadded:: 12.0
+    When using the `flex` type, TYPO3 takes care of
+    :ref:`generating the according database field <t3coreapi:auto-generated-db-structure>`.
+    A developer does not need to define this field in an extension's
+    :file:`ext_tables.sql` file.
+
 Renders a :ref:`FlexForm <flexforms>` element. Essentially, this consists in a
 hierarchically organized set of fields which will have their values saved into a
 single field in the database, stored as XML.

--- a/Documentation/ColumnsConfig/Type/Flex/Index.rst
+++ b/Documentation/ColumnsConfig/Type/Flex/Index.rst
@@ -5,7 +5,7 @@
 FlexForm field
 ==============
 
-..  versionadded:: 12.0
+..  versionadded:: 13.0
     When using the `flex` type, TYPO3 takes care of
     :ref:`generating the according database field <t3coreapi:auto-generated-db-structure>`.
     A developer does not need to define this field in an extension's


### PR DESCRIPTION
Related: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/666
Releases: main