### PR TITLE
[FEATURE] #101654 - Auto-create DB fields from TCA columns for type "email"

### DIFF
--- a/Documentation/ColumnsConfig/Type/Email/Index.rst
+++ b/Documentation/ColumnsConfig/Type/Email/Index.rst
@@ -6,9 +6,15 @@
 Email
 =====
 
-.. versionadded:: 12.0
-   The TCA type :php:`email` has been introduced. It replaces the
-   :php:`eval=email` option of TCA type :php:`input`.
+..  versionadded:: 12.0
+    The TCA type :php:`email` has been introduced. It replaces the
+    :php:`eval=email` option of TCA type :php:`input`.
+
+..  versionadded:: 13.0
+    When using the `flex` type, TYPO3 takes care of
+    :ref:`generating the according database field <t3coreapi:auto-generated-db-structure>`.
+    A developer does not need to define this field in an extension's
+    :file:`ext_tables.sql` file.
 
 The TCA type :php:`email` should be used to input values representing email
 addresses.

--- a/Documentation/ColumnsConfig/Type/Email/Index.rst
+++ b/Documentation/ColumnsConfig/Type/Email/Index.rst
@@ -11,7 +11,7 @@ Email
     :php:`eval=email` option of TCA type :php:`input`.
 
 ..  versionadded:: 13.0
-    When using the `flex` type, TYPO3 takes care of
+    When using the `email` type, TYPO3 takes care of
     :ref:`generating the according database field <t3coreapi:auto-generated-db-structure>`.
     A developer does not need to define this field in an extension's
     :file:`ext_tables.sql` file.


### PR DESCRIPTION
Related: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/641
Releases: main