### PR TITLE
[TASK] Add missing note about auto-created DB fields from TCA in v12

### DIFF
--- a/Documentation/ColumnsConfig/Type/Category/Index.rst
+++ b/Documentation/ColumnsConfig/Type/Category/Index.rst
@@ -13,6 +13,12 @@ Category
    as the :php:`ExtensionManagementUtility->makeCategorizable()`, which has required
    creating a "TCA overrides" file.
 
+..  versionadded:: 12.0
+    When using the `category` type, TYPO3 takes care of
+    :ref:`generating the according database field <t3coreapi:auto-generated-db-structure>`.
+    A developer does not need to define this field in an extension's
+    :file:`ext_tables.sql` file.
+
 While using the type :php:`category`, TYPO3 takes care of generating the
 necessary TCA configuration.
 Developers only have to define the TCA column and add :php:`category` as the

--- a/Documentation/ColumnsConfig/Type/Datetime/Index.rst
+++ b/Documentation/ColumnsConfig/Type/Datetime/Index.rst
@@ -7,9 +7,14 @@
 Datetime
 ========
 
-.. versionadded:: 12.0
-   The TCA type :php:`datetime` has been introduced. It replaces the
-   :php:`renderType=inputDateTime` of TCA type :php:`input`.
+..  versionadded:: 12.0
+    The TCA type :php:`datetime` has been introduced. It replaces the
+    :php:`renderType=inputDateTime` of TCA type :php:`input`.
+
+    When using the `datetime` type, TYPO3 takes care of
+    :ref:`generating the according database field <t3coreapi:auto-generated-db-structure>`.
+    A developer does not need to define this field in an extension's
+    :file:`ext_tables.sql` file.
 
 The TCA type :php:`datetime` should be used to input values representing a
 date time or datetime.

--- a/Documentation/ColumnsConfig/Type/Uuid/Index.rst
+++ b/Documentation/ColumnsConfig/Type/Uuid/Index.rst
@@ -7,6 +7,12 @@ Uuid
 ====
 
 ..  versionadded:: 12.3
+    The TCA type :php:`uuid` has been introduced.
+
+    When using the `uuid` type, TYPO3 takes care of
+    :ref:`generating the according database field <t3coreapi:auto-generated-db-structure>`.
+    A developer does not need to define this field in an extension's
+    :file:`ext_tables.sql` file.
 
 The main purpose of the TCA type :php:`uuid` is to simplify the TCA
 configuration when working with fields containing a `UUID`_.


### PR DESCRIPTION
Type "slug" has already this note, type "json" is not documented, yet.

See: https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/13.0/Feature-101553-Auto-createDBFieldsFromTCAColumns.html#impact
Releases: main, 12.4