### PR TITLE
[FEATURE] #102163 - Auto-create DB fields from TCA columns for type "radio"

### DIFF
--- a/Documentation/ColumnsConfig/Type/Radio/Index.rst
+++ b/Documentation/ColumnsConfig/Type/Radio/Index.rst
@@ -1,9 +1,15 @@
 ﻿.. include:: /Includes.rst.txt
 .. _columns-radio:
 
-============
-Radiobuttons
-============
+=============
+Radio buttons
+=============
+
+..  versionadded:: 13.0
+    When using the `radio` type, TYPO3 takes care of
+    :ref:`generating the according database field <t3coreapi:auto-generated-db-structure>`.
+    A developer does not need to define this field in an extension's
+    :file:`ext_tables.sql` file.
 
 This type creates a set of radio buttons. The value is typically stored as integer value, each radio
 item has one assigned number, but it can be a string, too.


### PR DESCRIPTION
Related: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/696
Releases: main