### PR TITLE
[TASK] #102224 - Add note about removing FlexForm dataStructure lookups in v13

### DIFF
--- a/Documentation/ColumnsConfig/Type/Flex/AboutDataStructures.rst
+++ b/Documentation/ColumnsConfig/Type/Flex/AboutDataStructures.rst
@@ -85,6 +85,10 @@ on a selected "tt_content" element plugin.
 Data structure lookup with tree traversal
 =========================================
 
+..  note::
+    This example will stop working with TYPO3 v13.
+    :ref:`More information <columns-flex-properties-ds-pointerfield-searchparent>`
+
 .. code-block:: php
 
     'config' => [
@@ -102,6 +106,10 @@ inheritance of data structure definition to sub pages and sub trees.
 
 Data structure lookup with tree traversal and pointing to a row in a foreign table
 ==================================================================================
+
+..  note::
+    This example will stop working with TYPO3 v13.
+    :ref:`More information <columns-flex-properties-ds-pointerfield-searchparent>`
 
 .. code-block:: php
 

--- a/Documentation/ColumnsConfig/Type/Flex/Properties/DsPointerFieldSearchParent.rst
+++ b/Documentation/ColumnsConfig/Type/Flex/Properties/DsPointerFieldSearchParent.rst
@@ -1,15 +1,25 @@
-.. include:: /Includes.rst.txt
-.. _columns-flex-properties-ds-pointerfield-searchparent:
+..  include:: /Includes.rst.txt
+..  _columns-flex-properties-ds-pointerfield-searchparent:
 
 ==============================
 ds\_pointerField\_searchParent
 ==============================
 
-.. confval:: ds_pointerField_searchParent
+..  note::
+    This configuration option will not be handled anymore with TYPO3 v13+.
+    Beginning with TYPO3 v12 you can migrate to PSR-14 events to manipulate the
+    data structure lookup logic:
 
-   :Path: $GLOBALS['TCA'][$table]['columns'][$field]['config']
-   :type: string
-   :Scope: Display  / Proc.
+    *   :ref:`AfterFlexFormDataStructureIdentifierInitializedEvent`
+    *   :ref:`AfterFlexFormDataStructureParsedEvent`
+    *   :ref:`BeforeFlexFormDataStructureIdentifierInitializedEvent`
+    *   :ref:`BeforeFlexFormDataStructureParsedEvent`
 
-   Used to search for Data Structure recursively back in the table assuming that the table is a tree table.
-   This value points to the "pid" field.
+..  confval:: ds_pointerField_searchParent
+
+    :Path: $GLOBALS['TCA'][$table]['columns'][$field]['config']
+    :type: string
+    :Scope: Display  / Proc.
+
+    Used to search for Data Structure recursively back in the table assuming that the table is a tree table.
+    This value points to the "pid" field.

--- a/Documentation/ColumnsConfig/Type/Flex/Properties/DsPointerFieldSearchParentSubField.rst
+++ b/Documentation/ColumnsConfig/Type/Flex/Properties/DsPointerFieldSearchParentSubField.rst
@@ -1,14 +1,24 @@
-.. include:: /Includes.rst.txt
-.. _columns-flex-properties-ds-pointerfield-searchparent-subfield:
+..  include:: /Includes.rst.txt
+..  _columns-flex-properties-ds-pointerfield-searchparent-subfield:
 
 ========================================
 ds\_pointerField\_searchParent\_subField
 ========================================
 
-.. confval:: ds_pointerField_searchParent_subField
+..  note::
+    This configuration option will not be handled anymore with TYPO3 v13+.
+    Beginning with TYPO3 v12 you can migrate to PSR-14 events to manipulate the
+    data structure lookup logic:
 
-   :Path: $GLOBALS['TCA'][$table]['columns'][$field]['config']
-   :type: string
-   :Scope: Display  / Proc.
+    *   :ref:`AfterFlexFormDataStructureIdentifierInitializedEvent`
+    *   :ref:`AfterFlexFormDataStructureParsedEvent`
+    *   :ref:`BeforeFlexFormDataStructureIdentifierInitializedEvent`
+    *   :ref:`BeforeFlexFormDataStructureParsedEvent`
 
-   Points to a field in the "rootline" which may contain a pointer to the "next-level" template.
+..  confval:: ds_pointerField_searchParent_subField
+
+    :Path: $GLOBALS['TCA'][$table]['columns'][$field]['config']
+    :type: string
+    :Scope: Display  / Proc.
+
+    Points to a field in the "rootline" which may contain a pointer to the "next-level" template.

--- a/Documentation/ColumnsConfig/Type/Flex/Properties/DsTableField.rst
+++ b/Documentation/ColumnsConfig/Type/Flex/Properties/DsTableField.rst
@@ -1,20 +1,30 @@
-.. include:: /Includes.rst.txt
-.. _columns-flex-properties-ds-tablefield:
+..  include:: /Includes.rst.txt
+..  _columns-flex-properties-ds-tablefield:
 
 ==============
 ds\_tableField
 ==============
 
-.. confval:: ds_tableField
+..  note::
+    This configuration option will not be handled anymore with TYPO3 v13+.
+    Beginning with TYPO3 v12 you can migrate to PSR-14 events to manipulate the
+    data structure lookup logic:
 
-   :Path: $GLOBALS['TCA'][$table]['columns'][$field]['config']
-   :type: string
-   :Scope: Display  / Proc.
+    *   :ref:`AfterFlexFormDataStructureIdentifierInitializedEvent`
+    *   :ref:`AfterFlexFormDataStructureParsedEvent`
+    *   :ref:`BeforeFlexFormDataStructureIdentifierInitializedEvent`
+    *   :ref:`BeforeFlexFormDataStructureParsedEvent`
 
-   Contains the value "[table]:[field name]" from which to fetch Data Structure XML.
+..  confval:: ds_tableField
 
-   :ref:`ds_pointerField <columns-flex-properties-ds-pointerfield>` is in this case the pointer which
-   should contain the uid of a record from that table.
+    :Path: $GLOBALS['TCA'][$table]['columns'][$field]['config']
+    :type: string
+    :Scope: Display  / Proc.
+
+    Contains the value "[table]:[field name]" from which to fetch Data Structure XML.
+
+    :ref:`ds_pointerField <columns-flex-properties-ds-pointerfield>` is in this case the pointer which
+    should contain the uid of a record from that table.
 
 Examples
 ========


### PR DESCRIPTION
As the migration of the lookups can already be done in v12, a note is added to those configuration options.

Related: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/705
Releases: 12.4