### PR TITLE
[TASK] Add anchor to "Migration" section of TCA type "file"

### DIFF
--- a/Documentation/ColumnsConfig/Type/File/Index.rst
+++ b/Documentation/ColumnsConfig/Type/File/Index.rst
@@ -1,5 +1,5 @@
-.. include:: /Includes.rst.txt
-.. _columns-file:
+..  include:: /Includes.rst.txt
+..  _columns-file:
 
 ====
 File
@@ -18,13 +18,13 @@ File
 The TCA type :php:`file` creates a field where files can be attached to
 the record.
 
-.. _columns-file-examples:
-.. _tca_example_group_file_1:
+..  _columns-file-examples:
+..  _tca_example_group_file_1:
 
 Examples
 ========
 
-.. code-block:: php
+..  code-block:: php
 
     'columns' => [
         'my_image' => [
@@ -36,6 +36,8 @@ Examples
             ],
         ],
     ],
+
+..  _columns-file-migration:
 
 Migration
 =========


### PR DESCRIPTION
This is needed to link from the "Using FAL" chapter in TYPO3 Explained to this section.

Releases: main, 12.4