### PR TITLE
Add missing quote in PHP code

### DIFF
--- a/Documentation/ColumnsConfig/Type/Group/Index.rst
+++ b/Documentation/ColumnsConfig/Type/Group/Index.rst
@@ -27,7 +27,7 @@ with lots of re-usable child records, and if :ref:`type='inline' <columns-inline
 
 This type is very flexible in its display options with all its different
 :ref:`fieldControl <columns-group-properties-fieldControl>` and
-:ref:`fieldWizard <tca_property_fieldWizard>` options. A lot of them are available by default, however they must be enabled: :php:`disabled' => 'false'`
+:ref:`fieldWizard <tca_property_fieldWizard>` options. A lot of them are available by default, however they must be enabled: :php:`'disabled' => 'false'`
 
 Most common usage is to model database relations (n:1 or n:m).
 The property :ref:`allowed <columns-group-properties-allowed>` is required, to


### PR DESCRIPTION
Usage of the quotes in PHP example code is inconsistent.