### PR TITLE
Remove exclusiveKeys property for some select renderTypes

### DIFF
--- a/Documentation/ColumnsConfig/Type/Select/CheckBox/Properties.rst
+++ b/Documentation/ColumnsConfig/Type/Select/CheckBox/Properties.rst
@@ -25,11 +25,6 @@ Select properties
 *  :ref:`items <columns-select-properties-items>`
 *  :ref:`MM <columns-select-properties-mm>`
 
-.. note::
-
-    The property :ref:`exclusiveKeys <columns-select-properties-exclusivekeys>`
-    is available only for the renderTypes selectMultipleSideBySide and selectTree.
-
 Common properties
 =================
 

--- a/Documentation/ColumnsConfig/Type/Select/CheckBox/Properties.rst
+++ b/Documentation/ColumnsConfig/Type/Select/CheckBox/Properties.rst
@@ -13,7 +13,6 @@ Select properties
 *  :ref:`authmode > enforce <columns-select-properties-authmode-enforce>`
 *  :ref:`default <columns-select-properties-default>`
 *  :ref:`disableNoMatchingValueElement <columns-select-properties-disableNoMatchingValueElement>`
-*  :ref:`exclusiveKeys <columns-select-properties-exclusivekeys>`
 *  :ref:`fileFolderConfig <columns-select-properties-fileFolderConfig>`
 
    *  :ref:`folder <columns-select-properties-fileFolderConfig.folder>`
@@ -25,6 +24,11 @@ Select properties
 *  :ref:`foreign_table_where <columns-select-properties-foreign-table-where>`
 *  :ref:`items <columns-select-properties-items>`
 *  :ref:`MM <columns-select-properties-mm>`
+
+.. note::
+
+    The property :ref:`exclusiveKeys <columns-select-properties-exclusivekeys>`
+    is available only for the renderTypes selectMultipleSideBySide and selectTree.
 
 Common properties
 =================

--- a/Documentation/ColumnsConfig/Type/Select/Properties/ExclusiveKeys.rst
+++ b/Documentation/ColumnsConfig/Type/Select/Properties/ExclusiveKeys.rst
@@ -15,6 +15,11 @@ exclusiveKeys
    List of keys that exclude any other keys in a select box where multiple
    items could be selected.
 
+.. note::
+
+    The property :php:`exclusiveKeys` is not available for all select types,
+    only for the renderTypes selectMultipleSideBySide and selectTree.
+
 Examples
 ========
 

--- a/Documentation/ColumnsConfig/Type/Select/Single/Properties.rst
+++ b/Documentation/ColumnsConfig/Type/Select/Single/Properties.rst
@@ -38,7 +38,6 @@ Select properties
 *  :ref:`authmode > enforce <columns-select-properties-authmode-enforce>`
 *  :ref:`default <columns-select-properties-default>`
 *  :ref:`disableNoMatchingValueElement <columns-select-properties-disableNoMatchingValueElement>`
-*  :ref:`exclusiveKeys <columns-select-properties-exclusivekeys>`
 *  :ref:`fileFolderConfig <columns-select-properties-fileFolderConfig>`
 
    *  :ref:`folder <columns-select-properties-fileFolderConfig.folder>`
@@ -51,6 +50,10 @@ Select properties
 *  :ref:`items <columns-select-properties-items>`
 *  :ref:`MM <columns-select-properties-mm>`
 
+.. note::
+
+    The property :ref:`exclusiveKeys <columns-select-properties-exclusivekeys>`
+    is available only for the renderTypes selectMultipleSideBySide and selectTree.
 
 Common properties
 =================

--- a/Documentation/ColumnsConfig/Type/Select/Single/Properties.rst
+++ b/Documentation/ColumnsConfig/Type/Select/Single/Properties.rst
@@ -50,11 +50,6 @@ Select properties
 *  :ref:`items <columns-select-properties-items>`
 *  :ref:`MM <columns-select-properties-mm>`
 
-.. note::
-
-    The property :ref:`exclusiveKeys <columns-select-properties-exclusivekeys>`
-    is available only for the renderTypes selectMultipleSideBySide and selectTree.
-
 Common properties
 =================
 

--- a/Documentation/ColumnsConfig/Type/Select/SingleBox/Properties.rst
+++ b/Documentation/ColumnsConfig/Type/Select/SingleBox/Properties.rst
@@ -24,11 +24,6 @@ Select properties
 *  :ref:`items <columns-select-properties-items>`
 *  :ref:`MM <columns-select-properties-mm>`
 
-.. note::
-
-    The property :ref:`exclusiveKeys <columns-select-properties-exclusivekeys>`
-    is available only for the renderTypes selectMultipleSideBySide and selectTree.
-
 Common properties
 =================
 

--- a/Documentation/ColumnsConfig/Type/Select/SingleBox/Properties.rst
+++ b/Documentation/ColumnsConfig/Type/Select/SingleBox/Properties.rst
@@ -12,7 +12,6 @@ Select properties
 *  :ref:`authmode > enforce <columns-select-properties-authmode-enforce>`
 *  :ref:`default <columns-select-properties-default>`
 *  :ref:`disableNoMatchingValueElement <columns-select-properties-disableNoMatchingValueElement>`
-*  :ref:`exclusiveKeys <columns-select-properties-exclusivekeys>`
 *  :ref:`fileFolderConfig <columns-select-properties-fileFolderConfig>`
 
    *  :ref:`folder <columns-select-properties-fileFolderConfig.folder>`
@@ -25,6 +24,10 @@ Select properties
 *  :ref:`items <columns-select-properties-items>`
 *  :ref:`MM <columns-select-properties-mm>`
 
+.. note::
+
+    The property :ref:`exclusiveKeys <columns-select-properties-exclusivekeys>`
+    is available only for the renderTypes selectMultipleSideBySide and selectTree.
 
 Common properties
 =================


### PR DESCRIPTION
The property exclusiveKeys is not available for all select types, it is only available for selectMultipleSideBySide and selectTree renderType (and category type).

The property is removed for the others and a note added.

The type category is left as is.

Resolves: #426