### PR TITLE
Show properties for renderTypes (v11.5 only)

### DIFF
--- a/Documentation/ColumnsConfig/Type/Input/ColorPicker/Index.rst
+++ b/Documentation/ColumnsConfig/Type/Input/ColorPicker/Index.rst
@@ -10,6 +10,10 @@ This page describes the :ref:`input <columns-input>` type with renderType='color
 
 An input field with a JavaScript color picker.
 
+Most input fields share :ref:`common properties <columns-input-properties>`.
+
 .. toctree::
 
    Examples
+
+

--- a/Documentation/ColumnsConfig/Type/Input/Default/Index.rst
+++ b/Documentation/ColumnsConfig/Type/Input/Default/Index.rst
@@ -13,6 +13,9 @@ This normal workhorse input element is used if no renderType is set and no speci
 It can display a simple input field, an input field with a value picker of predefined
 values or a value slider.
 
+Most input fields share :ref:`common properties <columns-input-properties>`.
+
 .. toctree::
 
    Examples
+

--- a/Documentation/ColumnsConfig/Type/Input/Link/Index.rst
+++ b/Documentation/ColumnsConfig/Type/Input/Link/Index.rst
@@ -10,8 +10,8 @@ This page describes the :ref:`input <columns-input>` type with the renderType='i
 
 An input field used to handle links and mail addresses in the backend.
 
-Additionally to the common properties :ref:`tca_field_control_link_popup` can
-be set.
+Additionally to the :ref:`common properties <columns-input-properties>`,
+:ref:`tca_field_control_link_popup` can be set.
 
 .. toctree::
 


### PR DESCRIPTION
The input render types usually have common properties, but these are not listed on the renderType pages, there is not a link to the properties there, only on the parent page.

This is a patch specific to v11.5 to add a link to the common properties page to the input renderType pages. This is handled differently in the versions >= 11.5.

Resolves: #668