### PR TITLE
Remove exclusiveKeys property for some select renderTypes (#861)

### DIFF
--- a/Documentation/ColumnsConfig/Type/Select/CheckBox/Properties.rst
+++ b/Documentation/ColumnsConfig/Type/Select/CheckBox/Properties.rst
@@ -14,7 +14,6 @@ Select properties
 *  :ref:`default <columns-select-properties-default>`
 *  :ref:`disableNoMatchingValueElement
    <columns-select-properties-disableNoMatchingValueElement>`
-*  :ref:`exclusivekeys <columns-select-properties-exclusivekeys>`
 *  :ref:`filefolder <columns-select-properties-filefolder>`
 *  :ref:`filefolder_extlist <columns-select-properties-filefolder-extlist>`
 *  :ref:`filefolder_recursions <columns-select-properties-filefolder-recursions>`

--- a/Documentation/ColumnsConfig/Type/Select/Properties/ExclusiveKeys.rst
+++ b/Documentation/ColumnsConfig/Type/Select/Properties/ExclusiveKeys.rst
@@ -15,6 +15,11 @@ exclusiveKeys
    List of keys that exclude any other keys in a select box where multiple
    items could be selected.
 
+.. note::
+
+    The property :php:`exclusiveKeys` is not available for all select types,
+    only for the renderTypes selectMultipleSideBySide and selectTree.
+
 Examples
 ========
 

--- a/Documentation/ColumnsConfig/Type/Select/Single/Properties.rst
+++ b/Documentation/ColumnsConfig/Type/Select/Single/Properties.rst
@@ -37,7 +37,6 @@ Select properties
 *  :ref:`authmode > enforce <columns-select-properties-authmode-enforce>`
 *  :ref:`default <columns-select-properties-default>`
 *  :ref:`disableNoMatchingValueElement <columns-select-properties-disableNoMatchingValueElement>`
-*  :ref:`exclusivekeys <columns-select-properties-exclusivekeys>`
 *  :ref:`filefolder <columns-select-properties-filefolder>`
 *  :ref:`filefolder_extlist <columns-select-properties-filefolder-extlist>`
 *  :ref:`filefolder_recursions <columns-select-properties-filefolder-recursions>`
@@ -46,7 +45,6 @@ Select properties
 *  :ref:`foreign_table_where <columns-select-properties-foreign-table-where>`
 *  :ref:`items <columns-select-properties-items>`
 *  :ref:`MM <columns-select-properties-mm>`
-
 
 Common properties
 =================

--- a/Documentation/ColumnsConfig/Type/Select/SingleBox/Properties.rst
+++ b/Documentation/ColumnsConfig/Type/Select/SingleBox/Properties.rst
@@ -12,7 +12,6 @@ Select properties
 *  :ref:`authmode > enforce <columns-select-properties-authmode-enforce>`
 *  :ref:`default <columns-select-properties-default>`
 *  :ref:`disableNoMatchingValueElement <columns-select-properties-disableNoMatchingValueElement>`
-*  :ref:`exclusivekeys <columns-select-properties-exclusivekeys>`
 *  :ref:`filefolder <columns-select-properties-filefolder>`
 *  :ref:`filefolder_extlist <columns-select-properties-filefolder-extlist>`
 *  :ref:`filefolder_recursions <columns-select-properties-filefolder-recursions>`
@@ -21,7 +20,6 @@ Select properties
 *  :ref:`foreign_table_where <columns-select-properties-foreign-table-where>`
 *  :ref:`items <columns-select-properties-items>`
 *  :ref:`MM <columns-select-properties-mm>`
-
 
 Common properties
 =================


### PR DESCRIPTION
The property exclusiveKeys is not available for all select types, it is only available for selectMultipleSideBySide and selectTree renderType.

The property is removed for the others and a note added.

The type category is left as is.

Resolves: #426