### PR TITLE
[FEATURE] #102237 - Auto-create DB fields from TCA columns for type "number"

### DIFF
--- a/Documentation/ColumnsConfig/Type/Number/Index.rst
+++ b/Documentation/ColumnsConfig/Type/Number/Index.rst
@@ -10,6 +10,12 @@ Number
    The TCA type :php:`number` has been introduced. It replaces the
    :php:`eval=int` and :php:`eval=double2` options of TCA type :php:`input`.
 
+..  versionadded:: 13.0
+    When using the `number` type, TYPO3 takes care of
+    :ref:`generating the according database field <t3coreapi:auto-generated-db-structure>`.
+    A developer does not need to define this field in an extension's
+    :file:`ext_tables.sql` file.
+
 
 The TCA type :php:`number` should be used to input values representing numbers.
 


### PR DESCRIPTION
Related: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/710
Releases: main