### PR TITLE
Fix missing backtick

### DIFF
--- a/Documentation/ColumnsConfig/Type/Select/Properties/ForeignTableWhere.rst
+++ b/Documentation/ColumnsConfig/Type/Select/Properties/ForeignTableWhere.rst
@@ -15,7 +15,7 @@ foreign_table_where
    The items from :ref:`foreign_table <columns-select-properties-foreign-table>`
    are selected with this :sql:`WHERE` clause. The :sql:`WHERE` clause is effectively
    appended to the existing :sql:`WHERE` clause (which contains default constraints,
-   such as :sql:`NOT deleted) and must begin with :sql:`AND`.
+   such as :sql:`NOT deleted`) and must begin with :sql:`AND`.
 
 Field quoting
 =============


### PR DESCRIPTION
Can be backported in 12.4 and 11.5 where the typo also exists.