### PR TITLE
Update allowed image types (#899)

### DIFF
--- a/Documentation/ColumnsConfig/Type/File/Index.rst
+++ b/Documentation/ColumnsConfig/Type/File/Index.rst
@@ -112,7 +112,7 @@ Another example without usage of the API method would therefore look like this:
             'label' => 'My image',
             'config' => [
                 'type' => 'file',
-                'allowed' => ['jpg','png','gif'],
+                'allowed' => 'jpg,png,gif',
             ],
         ],
     ],


### PR DESCRIPTION
['jpg','png','svg'] causes: PHP Warning: Array to string conversion in /var/www/html/vendor/typo3/cms-backend/Classes/Form/FieldControl/ElementBrowser.php line 77