### PR TITLE
[TASK] Use PHP 8.2 and allow Symfony 7

### DIFF
--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -1,7 +1,7 @@
 name: reference-tca
 type: php
 docroot: ""
-php_version: "8.1"
+php_version: "8.2"
 webserver_type: nginx-fpm
 router_http_port: "8081"
 router_https_port: "4434"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
     name: all tests
     runs-on: ubuntu-latest
     env:
-      php: '8.1'
+      php: '8.2'
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -1,8 +1,74 @@
 <?php
 
-$config = \TYPO3\CodingStandards\CsFixerConfig::create();
-$config
-    ->getFinder()->in(__DIR__)
-;
+declare(strict_types=1);
 
-return $config;
+use PhpCsFixer\Config;
+use PhpCsFixer\Finder;
+
+return (new Config())
+    ->setFinder(
+        (new Finder())
+            ->in(__DIR__)
+    )
+    ->setRiskyAllowed(true)
+    ->setRules([
+        '@DoctrineAnnotation' => true,
+        // @todo: Switch to @PER-CS2.0 once php-cs-fixer's todo list is done: https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues/7247
+        '@PER-CS1.0' => true,
+        'array_indentation' => true,
+        'array_syntax' => ['syntax' => 'short'],
+        'cast_spaces' => ['space' => 'none'],
+        // @todo: Can be dropped once we enable @PER-CS2.0
+        'concat_space' => ['spacing' => 'one'],
+        'declare_equal_normalize' => ['space' => 'none'],
+        'declare_parentheses' => true,
+        'dir_constant' => true,
+        // @todo: Can be dropped once we enable @PER-CS2.0
+        'function_declaration' => [
+            'closure_fn_spacing' => 'none',
+        ],
+        'function_to_constant' => ['functions' => ['get_called_class', 'get_class', 'get_class_this', 'php_sapi_name', 'phpversion', 'pi']],
+        'type_declaration_spaces' => true,
+        'global_namespace_import' => ['import_classes' => false, 'import_constants' => false, 'import_functions' => false],
+        'list_syntax' => ['syntax' => 'short'],
+        // @todo: Can be dropped once we enable @PER-CS2.0
+        'method_argument_space' => true,
+        'modernize_strpos' => true,
+        'modernize_types_casting' => true,
+        'native_function_casing' => true,
+        'no_alias_functions' => true,
+        'no_blank_lines_after_phpdoc' => true,
+        'no_empty_phpdoc' => true,
+        'no_empty_statement' => true,
+        'no_extra_blank_lines' => true,
+        'no_leading_namespace_whitespace' => true,
+        'no_null_property_initialization' => true,
+        'no_short_bool_cast' => true,
+        'no_singleline_whitespace_before_semicolons' => true,
+        'no_superfluous_elseif' => true,
+        'no_trailing_comma_in_singleline' => true,
+        'no_unneeded_control_parentheses' => true,
+        'no_unused_imports' => true,
+        'no_useless_else' => true,
+        'no_useless_nullsafe_operator' => true,
+        'ordered_imports' => ['imports_order' => ['class', 'function', 'const'], 'sort_algorithm' => 'alpha'],
+        'php_unit_construct' => ['assertions' => ['assertEquals', 'assertSame', 'assertNotEquals', 'assertNotSame']],
+        'php_unit_mock_short_will_return' => true,
+        'php_unit_test_case_static_method_calls' => ['call_type' => 'self'],
+        'phpdoc_no_access' => true,
+        'phpdoc_no_empty_return' => true,
+        'phpdoc_no_package' => true,
+        'phpdoc_scalar' => true,
+        'phpdoc_trim' => true,
+        'phpdoc_types' => true,
+        'phpdoc_types_order' => ['null_adjustment' => 'always_last', 'sort_algorithm' => 'none'],
+        'return_type_declaration' => ['space_before' => 'none'],
+        'single_quote' => true,
+        'single_space_around_construct' => true,
+        'single_line_comment_style' => ['comment_types' => ['hash']],
+        // @todo: Can be dropped once we enable @PER-CS2.0
+        'single_line_empty_body' => true,
+        'trailing_comma_in_multiline' => ['elements' => ['arrays']],
+        'whitespace_after_comma_in_array' => ['ensure_single_space' => true],
+        'yoda_style' => ['equal' => false, 'identical' => false, 'less_and_greater' => false],
+    ]);

--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -37,7 +37,7 @@ a recent docker-compose (tested >=1.21.2) is needed.
 
 Usage: $0 [options] [file]
 
-No arguments: Run all checks with PHP 8.1
+No arguments: Run all checks with PHP 8.2
 
 Options:
     -s <...>
@@ -48,10 +48,10 @@ Options:
             - lint: PHP linting
             - rector: Apply Rector rules
 
-    -p <8.1|8.2>
+    -p <8.2|8.3>
         Specifies the PHP minor version to be used
-            - 8.1 (default): use PHP 8.1
-            - 8.2: use PHP 8.2
+            - 8.2 (default): use PHP 8.2
+            - 8.3: use PHP 8.3
 
     -u
         Update existing typo3/core-testing-*:latest docker images. Maintenance call to docker pull latest
@@ -66,7 +66,7 @@ Options:
         Show this help.
 
 Examples:
-    # Run checks using PHP 8.1
+    # Run checks using PHP 8.2
     ./Build/Scripts/runTests.sh
 EOF
 
@@ -92,7 +92,7 @@ else
   ROOT_DIR=`realpath ${PWD}/../../`
 fi
 TEST_SUITE="cgl"
-PHP_VERSION="8.1"
+PHP_VERSION="8.2"
 SCRIPT_VERBOSE=0
 CGLCHECK_DRY_RUN=""
 IMAGE_PREFIX="ghcr.io/typo3/"
@@ -144,7 +144,7 @@ if [ ${#INVALID_OPTIONS[@]} -ne 0 ]; then
     exit 1
 fi
 
-# Move "8.1" to "php81", the latter is the docker container name
+# Move "8.2" to "php82", the latter is the docker container name
 DOCKER_PHP_IMAGE=`echo "php${PHP_VERSION}" | sed -e 's/\.//'`
 
 # Suite execution

--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,7 @@
     "typo3/cms-core": "dev-main as 12.4"
   },
   "require-dev": {
+    "friendsofphp/php-cs-fixer": "^3.46",
     "t3docs/codesnippet": "dev-main",
     "t3docs/examples": "dev-main",
     "t3docs/site-package": "dev-main",
@@ -44,8 +45,7 @@
     "typo3/cms-t3editor": "dev-main as 12.4",
     "typo3/cms-tstemplate": "dev-main as 12.4",
     "typo3/cms-viewpage": "dev-main as 12.4",
-    "typo3/cms-workspaces": "dev-main as 12.4",
-    "typo3/coding-standards": "^0.7.1"
+    "typo3/cms-workspaces": "dev-main as 12.4"
   },
   "minimum-stability": "dev",
   "prefer-stable": true,
@@ -55,6 +55,7 @@
       "typo3/class-alias-loader": true
     },
     "bin-dir": ".Build/bin",
+    "sort-packages": true,
     "vendor-dir": ".Build/vendor"
   },
   "extra": {


### PR DESCRIPTION
Also switch to php-cs-fixer directly, as typo3/coding-standards are not compatible with Symfony 7 by now. The fixer rules from Core are used.

Related: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/781
Related: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/786
Releases: main