### PR TITLE
[TASK] Remove old versionadded directives

### DIFF
--- a/Documentation/ColumnsConfig/Type/Select/Properties/ItemGroups.rst
+++ b/Documentation/ColumnsConfig/Type/Select/Properties/ItemGroups.rst
@@ -5,10 +5,6 @@
 itemGroups
 ==========
 
-.. versionadded:: 10.4
-   Starting with TYPO3 v10.4 item groups can be used in select fields to
-   group items.
-
 .. confval:: itemGroups
 
    :Path: $GLOBALS['TCA'][$table]['columns'][$field]['config']

--- a/Documentation/ColumnsConfig/Type/Select/Properties/SortItems.rst
+++ b/Documentation/ColumnsConfig/Type/Select/Properties/SortItems.rst
@@ -5,10 +5,6 @@
 sortItems
 =========
 
-.. versionadded:: 10.4
-   `sortItems` allows sorting of static select items
-   by their values or labels.
-
 .. confval:: sortItems
 
    :Path: $GLOBALS['TCA'][$table]['columns'][$field]['config']


### PR DESCRIPTION
The 10.4 version hints are removed as all LTS versions now support these features.

Releases: main, 12.4