### PR TITLE
[FEATURE] #95808 - Enable item groups for foreign_table for select type

### DIFF
--- a/Documentation/ColumnsConfig/Type/Select/Properties/ForeignTableItemGroup.rst
+++ b/Documentation/ColumnsConfig/Type/Select/Properties/ForeignTableItemGroup.rst
@@ -1,0 +1,47 @@
+..  include:: /Includes.rst.txt
+..  _columns-select-properties-foreign-table-item-group:
+
+===========================
+foreign\_table\_item\_group
+===========================
+
+..  versionadded:: 13.0
+
+..  confval:: foreign-table-item-group (type => select)
+
+    :Path: $GLOBALS['TCA'][$table]['columns'][$field]['config']
+    :type: string (column name)
+    :Scope: Proc. / Display
+    :RenderType: all
+
+    This property references a specific field in the
+    :ref:`foreign table <columns-select-properties-foreign-table>`, which
+    holds an :ref:`item group <columns-select-properties-item-groups>`
+    identifier.
+
+
+Example
+=======
+
+..  code-block:: php
+
+    'select_field' => [
+        'label' => 'select_field',
+        'config' => [
+            'type' => 'select',
+            'renderType' => 'selectSingle',
+            'items' => [
+                [
+                    'label' => 'static item 1',
+                    'value' => 'static-1',
+                    'group' => 'group1'
+                ],
+            ],
+            'itemGroups' => [
+                'group1' => 'Group 1 with items',
+                'group2' => 'Group 2 from foreign table',
+            ],
+            'foreign_table' => 'tx_myextension_foreign_table',
+            'foreign_table_item_group' => 'itemgroup'
+        ],
+    ],

--- a/Documentation/ColumnsConfig/Type/Select/Properties/Index.rst
+++ b/Documentation/ColumnsConfig/Type/Select/Properties/Index.rst
@@ -18,6 +18,7 @@ Select field properties
    ExclusiveKeys
    FileFolderConfig
    ForeignTable
+   ForeignTableItemGroup
    ForeignTablePrefix
    ForeignTableWhere
    ItemGroups

--- a/Documentation/ColumnsConfig/Type/Select/Properties/ItemGroups.rst
+++ b/Documentation/ColumnsConfig/Type/Select/Properties/ItemGroups.rst
@@ -30,9 +30,11 @@ itemGroups
    In the renderType `selectCheckbox` the groups are displayed as accordions
    containing the check boxes.
 
-   In other renderTypes a non selectable item with the
+   In other renderTypes a non-selectable item with the
    group name gets displayed.
 
+   Item groups can also be defined for items in
+   :ref:`foreign tables <columns-select-properties-foreign-table-item-group>`.
 
 API methods
 ===========


### PR DESCRIPTION
Related: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/776
Releases: main