### PR TITLE
[BUGFIX] Add missing category properties around foreign_table

### DIFF
--- a/Documentation/ColumnsConfig/Type/Category/Properties/ForeignTable.rst
+++ b/Documentation/ColumnsConfig/Type/Category/Properties/ForeignTable.rst
@@ -1,0 +1,22 @@
+..  include:: /Includes.rst.txt
+..  _columns-category-properties-foreign-table:
+
+==============
+foreign\_table
+==============
+
+..  confval:: foreign_table (type => category)
+
+    :Path: $GLOBALS['TCA'][$table]['columns'][$field]['config']
+    :type: string (table name)
+    :Scope: Proc. / Display
+    :RenderType: all
+
+    The item-array will be filled with records from the table defined here.
+    The table must have a TCA definition.
+
+    The uids of the chosen records will be saved in a comma-separated list
+    by default.
+
+    Use `property MM <columns-category-properties-mm>` to store the values in an
+    intermediate MM table instead.

--- a/Documentation/ColumnsConfig/Type/Category/Properties/ForeignTablePrefix.rst
+++ b/Documentation/ColumnsConfig/Type/Category/Properties/ForeignTablePrefix.rst
@@ -1,0 +1,18 @@
+..  include:: /Includes.rst.txt
+..  _columns-category-properties-foreign-table-prefix:
+
+====================
+foreign_table_prefix
+====================
+
+..  confval:: foreign_table_prefix (type => category)
+
+    :Path: $GLOBALS['TCA'][$table]['columns'][$field]['config']
+    :type: string or LLL reference
+    :Scope: Display
+    :RenderType: all
+
+    Label prefix to the title of the records from the foreign-table.
+
+    See also :ref:`property foreign_table_prefix of select field
+    <columns-select-properties-foreign-table-prefix>`.

--- a/Documentation/ColumnsConfig/Type/Category/Properties/ForeignTableWhere.rst
+++ b/Documentation/ColumnsConfig/Type/Category/Properties/ForeignTableWhere.rst
@@ -1,19 +1,19 @@
-.. include:: /Includes.rst.txt
-.. _columns-category-properties-foreign-table-where:
+..  include:: /Includes.rst.txt
+..  _columns-category-properties-foreign-table-where:
 
 ===================
 foreign_table_where
 ===================
 
-.. confval:: foreign_table_where (type => category)
+..  confval:: foreign_table_where (type => category)
 
-   :Path: $GLOBALS['TCA'][$table]['columns'][$field]['config']
-   :type: string (SQL WHERE)
-   :Scope: Proc. / Display
-   :Default:  :sql:`AND {#sys_category}.{#sys_language_uid} IN (-1, 0)`
+    :Path: $GLOBALS['TCA'][$table]['columns'][$field]['config']
+    :type: string (SQL WHERE)
+    :Scope: Proc. / Display
+    :Default: :sql:`AND {#sys_category}.{#sys_language_uid} IN (-1, 0)`
 
-   The items from :ref:`foreign_table <columns-select-properties-foreign-table>`
-   are selected with this :sql:`WHERE` clause. If set make sure to append the default value
-   to your query.
-   See also :ref:`property foreign_table_where of select field
-   <columns-select-properties-foreign-table-where>`.
+    The items from :ref:`foreign_table <columns-category-properties-foreign-table>`
+    are selected with this :sql:`WHERE` clause. If set make sure to append the
+    default value to your query.
+    See also :ref:`property foreign_table_where of select field
+    <columns-select-properties-foreign-table-where>`.

--- a/Documentation/ColumnsConfig/Type/Category/Properties/Index.rst
+++ b/Documentation/ColumnsConfig/Type/Category/Properties/Index.rst
@@ -15,7 +15,10 @@ Special properties
    ExclusiveKeys
    Relationship
    TreeConfig
+   ForeignTable
+   ForeignTablePrefix
    ForeignTableWhere
+   Mm
 
 
 Common properties

--- a/Documentation/ColumnsConfig/Type/Category/Properties/Mm.rst
+++ b/Documentation/ColumnsConfig/Type/Category/Properties/Mm.rst
@@ -1,0 +1,34 @@
+..  include:: /Includes.rst.txt
+..  _columns-category-properties-mm:
+
+==
+MM
+==
+
+..  versionadded:: 11.4
+    TCA table column fields that define :php:`['config']['MM']` can omit the
+    specification of the intermediate MM table layout in
+    :ref:`ext_tables.sql <t3coreapi:ext_tables-sql>`. The TYPO3 database
+    analyzer takes care of proper schema definition.
+
+    Extensions are strongly encouraged to drop :sql:`CREATE TABLE` definitions
+    from the :file:`ext_tables.sql` file for those intermediate tables
+    referenced by TCA table columns. Dropping these definitions allows the Core
+    to adapt and migrate definitions if needed.
+
+..  confval:: MM (type => category)
+
+    :Path: $GLOBALS['TCA'][$table]['columns'][$field]['config']
+    :type: string (table name)
+    :Scope: Proc.
+
+    This value contains the name of the table in which to store a MM relation.
+    It is used together with
+    :ref:`foreign_table <columns-category-properties-foreign-table>`.
+
+    The database field with a MM property only stores the number of records
+    in the relation.
+
+    Please have a look into the additional information
+    in the :ref:`MM common property description <tca_property_MM>`
+    and the :ref:`property MM of select field <columns-select-properties-mm>`

--- a/Documentation/ColumnsConfig/Type/Select/Properties/ForeignTablePrefix.rst
+++ b/Documentation/ColumnsConfig/Type/Select/Properties/ForeignTablePrefix.rst
@@ -5,7 +5,7 @@
 foreign_table_prefix
 ====================
 
-.. confval:: foreign_table_prefix
+.. confval:: foreign_table_prefix (type => select)
 
    :Path: $GLOBALS['TCA'][$table]['columns'][$field]['config']
    :type: string or LLL reference

--- a/Documentation/ColumnsConfig/Type/Select/Properties/ForeignTableWhere.rst
+++ b/Documentation/ColumnsConfig/Type/Select/Properties/ForeignTableWhere.rst
@@ -5,7 +5,7 @@
 foreign_table_where
 =====================
 
-.. confval:: foreign_table_where
+.. confval:: foreign_table_where (type => select)
 
    :Path: $GLOBALS['TCA'][$table]['columns'][$field]['config']
    :type: string (SQL WHERE)


### PR DESCRIPTION
"foreign_table_where" is already available, the other properties were missing.

Releases: main, 12.4, 11.5