### PR TITLE
[TASK] Add missing itemGroups property to category type

### DIFF
--- a/Documentation/ColumnsConfig/Type/Category/Properties/ForeignTable.rst
+++ b/Documentation/ColumnsConfig/Type/Category/Properties/ForeignTable.rst
@@ -10,7 +10,6 @@ foreign\_table
     :Path: $GLOBALS['TCA'][$table]['columns'][$field]['config']
     :type: string (table name)
     :Scope: Proc. / Display
-    :RenderType: all
 
     The item-array will be filled with records from the table defined here.
     The table must have a TCA definition.

--- a/Documentation/ColumnsConfig/Type/Category/Properties/ForeignTablePrefix.rst
+++ b/Documentation/ColumnsConfig/Type/Category/Properties/ForeignTablePrefix.rst
@@ -10,7 +10,6 @@ foreign_table_prefix
     :Path: $GLOBALS['TCA'][$table]['columns'][$field]['config']
     :type: string or LLL reference
     :Scope: Display
-    :RenderType: all
 
     Label prefix to the title of the records from the foreign-table.
 

--- a/Documentation/ColumnsConfig/Type/Category/Properties/Index.rst
+++ b/Documentation/ColumnsConfig/Type/Category/Properties/Index.rst
@@ -1,6 +1,6 @@
-.. include:: /Includes.rst.txt
+..  include:: /Includes.rst.txt
 
-.. _columns-category-properties:
+..  _columns-category-properties:
 
 =========================
 Category field properties
@@ -9,25 +9,19 @@ Category field properties
 Special properties
 ==================
 
-.. toctree::
+..  toctree::
+    :titlesonly:
+    :glob:
 
-   Default
-   ExclusiveKeys
-   ForeignTable
-   ForeignTablePrefix
-   ForeignTableWhere
-   ItemGroups
-   Mm
-   Relationship
-   TreeConfig
+    *
 
 
 Common properties
 =================
 
-*  :ref:`maxitems <tca_property_maxitems>`
-*  :ref:`minitems <tca_property_minitems>`
-*  :ref:`readOnly <tca_property_readOnly>`
-*  :ref:`size <tca_property_size>` maximal number of elements to be displayed
-   by default
+*   :ref:`maxitems <tca_property_maxitems>`
+*   :ref:`minitems <tca_property_minitems>`
+*   :ref:`readOnly <tca_property_readOnly>`
+*   :ref:`size <tca_property_size>` maximal number of elements to be displayed
+    by default
 

--- a/Documentation/ColumnsConfig/Type/Category/Properties/Index.rst
+++ b/Documentation/ColumnsConfig/Type/Category/Properties/Index.rst
@@ -13,12 +13,13 @@ Special properties
 
    Default
    ExclusiveKeys
-   Relationship
-   TreeConfig
    ForeignTable
    ForeignTablePrefix
    ForeignTableWhere
+   ItemGroups
    Mm
+   Relationship
+   TreeConfig
 
 
 Common properties

--- a/Documentation/ColumnsConfig/Type/Category/Properties/ItemGroups.rst
+++ b/Documentation/ColumnsConfig/Type/Category/Properties/ItemGroups.rst
@@ -1,0 +1,24 @@
+..  include:: /Includes.rst.txt
+..  _columns-category-properties-item-groups:
+
+==========
+itemGroups
+==========
+
+..  confval:: itemGroups (type => category)
+
+    :Path: $GLOBALS['TCA'][$table]['columns'][$field]['config']
+    :type: array
+    :Scope: Display  / Proc.
+    :RenderType: all
+
+    Contains an array of key-value pairs. The key contains the id of the item
+    group, the value contains the label of the item group or its language
+    reference.
+
+    Only groups containing items will be displayed. In the select field first all
+    items with no group defined are listed then the item groups in the order of
+    their definition, each group with the corresponding items.
+
+    See also :ref:`property itemGroups of select field
+    <columns-select-properties-item-groups>`.

--- a/Documentation/ColumnsConfig/Type/Select/Properties/ItemGroups.rst
+++ b/Documentation/ColumnsConfig/Type/Select/Properties/ItemGroups.rst
@@ -5,7 +5,7 @@
 itemGroups
 ==========
 
-.. confval:: itemGroups
+.. confval:: itemGroups (type => select)
 
    :Path: $GLOBALS['TCA'][$table]['columns'][$field]['config']
    :type: array


### PR DESCRIPTION
Additionally, "RenderType" for properties "foreign_table" and "foreign_table_prefix" have been removed as category has no render types. The toctree is also ordered alphabetically.

Releases: main, 12.4