### PR TITLE
[TASK] Remove wrong default for type `file` `allowed`

### DIFF
--- a/Documentation/ColumnsConfig/Type/File/Properties/Allowed.rst
+++ b/Documentation/ColumnsConfig/Type/File/Properties/Allowed.rst
@@ -10,7 +10,6 @@ allowed
     :Path: $GLOBALS['TCA'][$table]['columns'][$field]['config']
     :type: string / array
     :Scope: Proc. / Display
-    :Default: `common-image-types`
 
     One of the following reserved strings:
 


### PR DESCRIPTION
This is not documented anywhere and didn't work as well when testing. The code for this is:

```
if (!empty(($allowed = ($fieldConfig['config']['allowed'] ?? null)))) {
    $fieldConfig['config']['allowed'] = self::prepareFileExtensions($allowed);
}
```

Releases: main, 12.4