### PR TITLE
[FEATURE] #95808 - Enable item groups for foreign_table for category type

### DIFF
--- a/Documentation/ColumnsConfig/Type/Category/Properties/ForeignTableItemGroup.rst
+++ b/Documentation/ColumnsConfig/Type/Category/Properties/ForeignTableItemGroup.rst
@@ -1,0 +1,22 @@
+..  include:: /Includes.rst.txt
+..  _columns-category-properties-foreign-table-item-group:
+
+===========================
+foreign\_table\_item\_group
+===========================
+
+..  versionadded:: 13.0
+
+..  confval:: foreign_table_item_group (type => category)
+
+    :Path: $GLOBALS['TCA'][$table]['columns'][$field]['config']
+    :type: string (column name)
+    :Scope: Proc. / Display
+
+    This property references a specific field in the
+    :ref:`foreign table <columns-category-properties-foreign-table>`, which
+    holds an :ref:`item group <columns-category-properties-item-groups>`
+    identifier.
+
+    See also :ref:`property foreign_table_item_group of select field
+    <columns-select-properties-foreign-table-item-group>`.

--- a/Documentation/ColumnsConfig/Type/Select/Properties/ForeignTableItemGroup.rst
+++ b/Documentation/ColumnsConfig/Type/Select/Properties/ForeignTableItemGroup.rst
@@ -7,7 +7,7 @@ foreign\_table\_item\_group
 
 ..  versionadded:: 13.0
 
-..  confval:: foreign-table-item-group (type => select)
+..  confval:: foreign_table_item_group (type => select)
 
     :Path: $GLOBALS['TCA'][$table]['columns'][$field]['config']
     :type: string (column name)


### PR DESCRIPTION
Additionally, fix the confval value of the corresponding select property.

Resolves: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/776
Releases: main