### PR TITLE
Link file TCA field to code to load them

### DIFF
--- a/Documentation/ColumnsConfig/Type/File/Index.rst
+++ b/Documentation/ColumnsConfig/Type/File/Index.rst
@@ -18,6 +18,10 @@ File
 The TCA type :php:`file` creates a field where files can be attached to
 the record.
 
+.. seealso::
+
+   :ref:`<t3coreapi:fal-using-fal-examples-file-folder-get-references>`
+
 ..  _columns-file-examples:
 ..  _tca_example_group_file_1:
 
@@ -124,4 +128,3 @@ Properties
    :titlesonly:
 
    Properties/Index
-


### PR DESCRIPTION
https://docs.typo3.org/m/typo3/reference-tca/12.4/en-us/ColumnsConfig/Type/File/Index.html
shall link to
https://docs.typo3.org/m/typo3/reference-coreapi/12.4/en-us/ApiOverview/Fal/UsingFal/ExamplesFileFolder.html#getting-referenced-files