### PR TITLE
[TASK] Add note about breaking flex form section change

### DIFF
--- a/Documentation/ColumnsConfig/Type/Flex/FlexformSyntax.rst
+++ b/Documentation/ColumnsConfig/Type/Flex/FlexformSyntax.rst
@@ -32,7 +32,7 @@ documented here for TCA. The limitations are:
 .. versionchanged:: 13.0
 
     Since TYPO3 13.0, also :php:`type='select'` (when using
-    :php:`foreign_table`) is not allowed to be used and will raise an exception
+    :php:`foreign_table`) is not allowed and will raise an exception
     when used. Note this only applies to flex form sections, not general
     flexform usage.
 

--- a/Documentation/ColumnsConfig/Type/Flex/FlexformSyntax.rst
+++ b/Documentation/ColumnsConfig/Type/Flex/FlexformSyntax.rst
@@ -27,7 +27,7 @@ documented here for TCA. The limitations are:
 -  Charset follows that of the current backend UTF-8. When storing FlexForm information in external files,
    make sure that they are using UTF-8 too.
 
--  :php:`type='inline'` and other types that point to different tables are not allowed in flex form section containers.
+-  :php:`type='inline'` and other types that point to different tables are not allowed in FlexForm section containers.
 
 .. versionchanged:: 13.0
 

--- a/Documentation/ColumnsConfig/Type/Flex/FlexformSyntax.rst
+++ b/Documentation/ColumnsConfig/Type/Flex/FlexformSyntax.rst
@@ -33,7 +33,7 @@ documented here for TCA. The limitations are:
 
     Since TYPO3 13.0, also :php:`type='select'` (when using
     :php:`foreign_table`) is not allowed and will raise an exception
-    when used. Note this only applies to flex form sections, not general
+    when used. Note this only applies to FlexForm sections, not general
     flexform usage.
 
 .. _columns-flex-tceforms:

--- a/Documentation/ColumnsConfig/Type/Flex/FlexformSyntax.rst
+++ b/Documentation/ColumnsConfig/Type/Flex/FlexformSyntax.rst
@@ -32,7 +32,7 @@ documented here for TCA. The limitations are:
 .. versionchanged:: 13.0
 
     Since TYPO3 13.0, also :php:`type='select'` (when using
-    :php`foreign_table`) is not allowed to be used and will raise an exception
+    :php:`foreign_table`) is not allowed to be used and will raise an exception
     when used. Note this only applies to flex form sections, not general
     flexform usage.
 

--- a/Documentation/ColumnsConfig/Type/Flex/FlexformSyntax.rst
+++ b/Documentation/ColumnsConfig/Type/Flex/FlexformSyntax.rst
@@ -34,7 +34,7 @@ documented here for TCA. The limitations are:
     Since TYPO3 13.0, also :php:`type='select'` (when using
     :php:`foreign_table`) is not allowed and will raise an exception
     when used. Note this only applies to FlexForm sections, not general
-    flexform usage.
+    FlexForm usage.
 
 .. _columns-flex-tceforms:
 

--- a/Documentation/ColumnsConfig/Type/Flex/FlexformSyntax.rst
+++ b/Documentation/ColumnsConfig/Type/Flex/FlexformSyntax.rst
@@ -27,7 +27,14 @@ documented here for TCA. The limitations are:
 -  Charset follows that of the current backend UTF-8. When storing FlexForm information in external files,
    make sure that they are using UTF-8 too.
 
--  :php:`type='inline'` and other type's that point to different tables are not allowed in flex form section containers.
+-  :php:`type='inline'` and other types that point to different tables are not allowed in flex form section containers.
+
+.. versionchanged:: 13.0
+
+    Since TYPO3 13.0, also :php:`type='select'` (when using
+    :php`foreign_table`) is not allowed to be used and will raise an exception
+    when used. Note this only applies to flex form sections, not general
+    flexform usage.
 
 .. _columns-flex-tceforms:
 


### PR DESCRIPTION
type="select" is no longer allowed.
Resolves: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/836