### PR TITLE
Update list of valid searchable field types

### DIFF
--- a/Documentation/Ctrl/Properties/SearchFields.rst
+++ b/Documentation/Ctrl/Properties/SearchFields.rst
@@ -23,6 +23,8 @@ searchFields
    *  :ref:`link <columns-link>`
    *  :ref:`slug <columns-slug>`
    *  :ref:`color <columns-color>`
+   *  :ref:`json <columns-json>`
+   *  :ref:`uuid <columns-uuid>`
 
    Adding fields of different types to `searchFields` has no effect.
 


### PR DESCRIPTION
Added uuid and json as valid field types. These were added in TYPO3 v12 and are available to be used in the live search.