### PR TITLE
[TASK] Fix wrong default renderType for type check

### DIFF
--- a/Documentation/ColumnsConfig/Type/Check/Default.rst
+++ b/Documentation/ColumnsConfig/Type/Check/Default.rst
@@ -8,10 +8,10 @@
 Default checkbox
 ================
 
-The checkbox with :ref:`renderType default <columns-check-properties-renderType>`
+The checkbox with :ref:`renderType check <columns-check-properties-renderType>`
 is typically a single checkbox or a group of checkboxes.
 
-Its state can be inverted via :code:`invertStateDisplay`.
+Its state can be inverted via :php:`invertStateDisplay`.
 
 .. _columns-check-examples:
 .. _columns-check-examples-single:

--- a/Documentation/ColumnsConfig/Type/Check/Properties/RenderType.rst
+++ b/Documentation/ColumnsConfig/Type/Check/Properties/RenderType.rst
@@ -10,11 +10,11 @@ renderType
    :Path: $GLOBALS['TCA'][$table]['columns'][$field]['config']
    :type: boolean
    :Scope: Display
-   :Default: default
+   :Default: check
 
    Three different render types are currently available for the check box field:
 
-   *  :ref:`default <columns-check-default>`
+   *  :ref:`check <columns-check-default>`
    *  :ref:`checkboxToggle <columns-check-checkboxToggle>`
    *  :ref:`checkboxLabeledToggle <columns-check-checkboxLabeledToggle>`
 


### PR DESCRIPTION
The default value for `renderType` is always equivalent to the `type`. There does not exist a renderType with the value `default`. The actual default is the value `check`, the same as the type.

Releases: main, 12.4, 11.5