### PR TITLE
[BUGFIX] Remove "showRemovedLocalizationRecords" from "inline" options

### DIFF
--- a/Documentation/ColumnsConfig/Properties/InlineAppearance.rst.txt
+++ b/Documentation/ColumnsConfig/Properties/InlineAppearance.rst.txt
@@ -60,9 +60,6 @@
     showPossibleLocalizationRecords (boolean)
       Show unlocalized records which are in the original language, but not yet localized.
 
-    showRemovedLocalizationRecords (boolean)
-      Show records which were once localized but do not exist in the original language anymore.
-
     showAllLocalizationLink (boolean)
       Defines whether to show the "localize all records" link to fetch untranslated records from the original language.
 


### PR DESCRIPTION
This option was removed with TYPO3v7, see https://review.typo3.org/c/Packages/TYPO3.CMS/+/44363