### PR TITLE
[BUGFIX] Remove "showRemovedLocalizationRecords" from "inline" example (v9)

### DIFF
--- a/Documentation/ColumnsConfig/Type/Inline.rst
+++ b/Documentation/ColumnsConfig/Type/Inline.rst
@@ -180,7 +180,6 @@ options (second call parameter) are merged looks like:
                 'height' => '45c',
             ],
             'showPossibleLocalizationRecords' => false,
-            'showRemovedLocalizationRecords' => false,
             'showSynchronizationLink' => false,
             'showAllLocalizationLink' => false,
 


### PR DESCRIPTION
This option was removed with TYPO3v7, see https://review.typo3.org/c/Packages/TYPO3.CMS/+/44363