### PR TITLE
[BUGFIX] Remove "showRemovedLocalizationRecords" from "inline" example (v8)

### DIFF
--- a/Documentation/ColumnsConfig/Type/Inline.rst
+++ b/Documentation/ColumnsConfig/Type/Inline.rst
@@ -175,7 +175,6 @@ options (second call parameter) are merged looks like:
                 'height' => '45c',
             ],
             'showPossibleLocalizationRecords' => FALSE,
-            'showRemovedLocalizationRecords' => FALSE,
             'showSynchronizationLink' => FALSE,
             'showAllLocalizationLink' => FALSE,
 


### PR DESCRIPTION
This option was removed with TYPO3v7, see https://review.typo3.org/c/Packages/TYPO3.CMS/+/44363