### PR TITLE
remove field "t3ver_id" from docs

### DIFF
--- a/Documentation/Ctrl/Properties/VersioningWS.rst
+++ b/Documentation/Ctrl/Properties/VersioningWS.rst
@@ -42,9 +42,6 @@ versioningWS
      For offline versions; pointing back to online
      version uid. For online: 0 (zero)
 
-   t3ver\_id
-     Incremental integer (version number)
-
    t3ver\_wsid
      For offline versions: Workspace ID of version.
      For all workspace Ids apart from 0 (zero) there can be only one


### PR DESCRIPTION
in typo3 version 10 this field was removed.

Releated Changelog:
https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/10.0/Breaking-88143-Version-relatedDatabaseFieldT3ver_idRemoved.html