### PR TITLE
nullable is still missing in the docs

### DIFF
--- a/Documentation/ColumnsConfig/CommonProperties/Index.rst
+++ b/Documentation/ColumnsConfig/CommonProperties/Index.rst
@@ -21,6 +21,7 @@ Common properties
    Mm
    Mode
    Multiple
+   Nullable
    Placeholder
    ReadOnly
    Required

--- a/Documentation/ColumnsConfig/CommonProperties/Nullable.rst
+++ b/Documentation/ColumnsConfig/CommonProperties/Nullable.rst
@@ -1,0 +1,25 @@
+.. include:: /Includes.rst.txt
+.. _tca_property_nullable:
+
+========
+nullable
+========
+
+.. versionadded:: 12.0
+   This option should be used instead of an `eval` property with the
+   deprecated keyword `null`.
+
+.. confval:: nullable
+
+   :Path: $GLOBALS['TCA'][$table]['columns'][$field]['config']
+   :type: boolean
+   :Scope: Display / Proc.
+   :Default: false
+   :Types:
+      :ref:`input <columns-input>`,
+      :ref:`text <columns-text>`
+
+   If set to true a null value is possible in the field. The
+   form can be saved even if no entries have been made.
+   The database field must not forbid the :sql:`NULL` value.
+


### PR DESCRIPTION
See TYPO3 12.0 

Feature: #97384 - TCA option "nullable"


