### PR TITLE
[TASK] Improve array/string notation for TCA 'allowed' on file types

### DIFF
--- a/Documentation/ColumnsConfig/Type/File/Index.rst
+++ b/Documentation/ColumnsConfig/Type/File/Index.rst
@@ -115,6 +115,7 @@ Another example without usage of the API method would therefore look like this:
             'label' => 'My image',
             'config' => [
                 'type' => 'file',
+                // Can also be an array of file extensions as of TYPO3 v12.4.14+
                 'allowed' => 'jpg,png,gif',
             ],
         ],

--- a/Documentation/ColumnsConfig/Type/File/Properties/Allowed.rst
+++ b/Documentation/ColumnsConfig/Type/File/Properties/Allowed.rst
@@ -11,7 +11,7 @@ allowed
     :type: string / array
     :Scope: Proc. / Display
 
-    One of the following reserved strings:
+    One or more (comma separated) of the following reserved strings:
 
     `common-image-types`
         Gets replaced with the value from
@@ -25,5 +25,15 @@ allowed
         Gets replaced with the value from
         :php:`$GLOBALS['TYPO3_CONF_VARS']['SYS']['mediafile_ext']`.
 
-    or an array of allowed file
-    endings, for example :php:`['jpg','png','svg']`.
+    Additionally, specific allowed file extensions can be added (comma
+    separated), for example
+    :php:`'common-image-types, common-text-types, gz, zip`.
+
+    You can also use the array notation of allowed file extensions, for example
+    :php:`['jpg','png','svg']` or :php:`['common-image-types', 'gz', 'zip']`.
+
+..  versionadded:: 12.4.14
+    Due to a bug, the array notation only properly works
+    since TYPO3 v12.4.1 (and 13.1.0) and upwards. Use the string notation
+    for earlier versions instead.
+


### PR DESCRIPTION
After an initiative of  Lars Trebing (via https://typo3.slack.com/archives/C03AM9R17/p1712352682709819) we need to clarify this part of the documentation.

It is not explained more thoroughly how string | array definitions can be used, and that it only works with an Array starting with the next TYPO3 release (likely tomorrow). The relevant bugfix for this is https://review.typo3.org/c/Packages/TYPO3.CMS/+/83649.

For reference, the changelog https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/12.0/Feature-98479-NewTCATypeFile.html explicitly allows:

> It's possible to use **multiple placeholders**. 
> It's also possible to **mix them** with single file extensions. 
> Additionally, it's also possible to define the **file extensions as `array`**.

(I ensured the examples I listed work in current TYPO3 main+12.4-dev)

Further references on previous changes:
https://github.com/TYPO3-Documentation/TYPO3CMS-Reference-TCA/pull/899
https://github.com/TYPO3-Documentation/TYPO3CMS-Reference-TCA/pull/902

Releases: main, 12.4