### PR TITLE
prefixParentPageSlug is only for pages

### DIFF
--- a/Documentation/CodeSnippets/Slug5.rst.txt
+++ b/Documentation/CodeSnippets/Slug5.rst.txt
@@ -17,7 +17,6 @@
                                'input_2',
                            ],
                        ],
-                       'prefixParentPageSlug' => false,
                    ],
                    'fallbackCharacter' => '-',
                    'eval' => 'uniqueInSite',


### PR DESCRIPTION
prefixParentPageSlug should not be mentioned in record examples.

https://docs.typo3.org/m/typo3/reference-tca/main/en-us/ColumnsConfig/Type/Slug/Properties/GeneratorOptions.html#generatoroptions

Do not immediately accept this pull request.
Tell me your opinion, then I will add more example files where the prefixParentPageSlug should be removed. 