### PR TITLE
appeareance prefix is the URL

### DIFF
--- a/Documentation/ColumnsConfig/Type/Slug/Properties/Appearance.rst
+++ b/Documentation/ColumnsConfig/Type/Slug/Properties/Appearance.rst
@@ -20,6 +20,7 @@ appearance
     :Scope: Display
 
     Provides a string that is displayed in front of the input field.
+    The URL of the site is set by default if nothing has been defined.
 
     Assign a user function. It receives two arguments:
 


### PR DESCRIPTION
Add a hint that TYPO3 sets the prefix to the URL by default.