### PR TITLE
Consistent use of l10n_ as prefix for all localization fields

### DIFF
--- a/Documentation/CodeSnippets/Manual/Ctrl/Language.rst.txt
+++ b/Documentation/CodeSnippets/Manual/Ctrl/Language.rst.txt
@@ -5,8 +5,8 @@
 
    return [
        'ctrl' => [
-           'transOrigPointerField' => 'l18n_parent',
-           'transOrigDiffSourceField' => 'l18n_diffsource',
+           'transOrigPointerField' => 'l10n_parent',
+           'transOrigDiffSourceField' => 'l10n_diffsource',
            'languageField' => 'sys_language_uid',
            'translationSource' => 'l10n_source',
            // ...
@@ -19,7 +19,7 @@
                    'type' => 'language',
                ],
            ],
-           'l18n_parent' => [
+           'l10n_parent' => [
                'displayCond' => 'FIELD:sys_language_uid:>:0',
                'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.l18n_parent',
                'config' => [
@@ -43,7 +43,7 @@
                    'type' => 'passthrough',
                ],
            ],
-           'l18n_diffsource' => [
+           'l10n_diffsource' => [
                'config' => [
                    'type' => 'passthrough',
                    'default' => '',

--- a/Documentation/ColumnsConfig/Type/Passthrough/Index.rst
+++ b/Documentation/ColumnsConfig/Type/Passthrough/Index.rst
@@ -32,7 +32,7 @@ The `passthrough` field can be useful, if:
 
 * A field needs no rendering, but some data handling using hooks of the `DataHandler`.
 * The passthrough type is used by TYPO3 core to handle meta data on records rows that are not shown as fields
-  if editing records and only have data logic attached to it. An example is the `l18n_diffsource` field whose
+  if editing records and only have data logic attached to it. An example is the `l10n_diffsource` field whose
   data is rendered differently in FormEngine at other places if editing a record but still updated and handled
   by the `DataHandler`.
 

--- a/Documentation/Ctrl/Properties/TranslationSource.rst
+++ b/Documentation/Ctrl/Properties/TranslationSource.rst
@@ -24,7 +24,7 @@ translationSource
 
    For example, if a tt_content record in default language English with uid 13 exists, this record is translated
    to French with uid 17, and the Danish translation is later created based on the French translation, then the
-   Danish translation has uid 13 set as :sql:`l18n_parent` and 17 as :sql:`l10n_source`.
+   Danish translation has uid 13 set as :sql:`l10n_parent` and 17 as :sql:`l10n_source`.
 
 Example
 =======


### PR DESCRIPTION
As mentioned several times throughout the TCA documentation, l10n_ should be used by convention, and l18n_ must be kept for some core tables for historic reasons. l10n_ should therefore be used consistently, except when explaining those historic reasons.