### PR TITLE
Add info about wrong icon usage

### DIFF
--- a/Documentation/Ctrl/Properties/GroupName.rst
+++ b/Documentation/Ctrl/Properties/GroupName.rst
@@ -5,13 +5,21 @@
 groupName
 =========
 
-.. confval:: groupName
-   :name: ctrl-groupName
-   :Path: $GLOBALS['TCA'][$table]['ctrl']
-   :type: string
-   :Scope: Special
+..  confval:: groupName
+    :name: ctrl-groupName
+    :Path: $GLOBALS['TCA'][$table]['ctrl']
+    :type: string
+    :Scope: Special
 
+    This option can be used to group records in the new record wizard. If you define a new table and set
+    its "groupName" to the key of another extension, the table will appear in the list of records from that
+    other extension in the new record wizard.
 
-   This option can be used to group records in the new record wizard. If you define a new table and set
-   its "groupName" to the key of another extension, the table will appear in the list of records from that
-   other extension in the new record wizard.
+    We really appreciate you setting the `ctrl` property `title` to a localized value (`LLL:EXT:`), otherwise 
+    it may happen that TYPO3 cannot extract the correct extension key from your table name, resulting in  
+    wrong icons in list of new record wizard. This only happens if your extension key contains
+    underscores `_`, but the second part of your table name does not. For example: If your extension key 
+    is `my_extension` the table names will normally start with `tx_myextension`. Since `myextension` does not
+    match the real extension key `my_extension`, the icon of your extension cannot be retrieved from your 
+    extension. Instead of a localized `title`, you can also set `groupName` to your real extension
+    key: `my_extension`.


### PR DESCRIPTION
It's the third time now that I stumbled over the problem, that in create new record wizard the icon of my group is from a foreign extension. This time it was the icon of tx_scheduler, which has nothing to do with my extension. TYPO3 tries to find a loaded extension by the second part of the tablename. This is OK for all extensions without underscore. But with underscore the second part of table name does not match any extension key. That's why it comes to these side-effects. Easiest solution is to enter a localized title. In that case the extension key will be extracted from the LLL:EXT: path. Else you should set groupName to your extension key. That way an extension can be found and the correct group icon (ext icon) will be shown again