### PR TITLE
Update Index.rst, fixed spelling

### DIFF
--- a/Documentation/BestPractises/Index.rst
+++ b/Documentation/BestPractises/Index.rst
@@ -1,7 +1,7 @@
 ..  include:: /Includes.rst.txt
 
 ==============
-Best practises
+Best practices
 ==============
 
 Some configuration settings are applied to almost all tables in TYPO3. See the following


### PR DESCRIPTION
Updated spelling, see
https://www.scribbr.com/us-vs-uk/practise-or-practice/ for details.

"to practise is only a verb in UK, in US it is never used"