### PR TITLE
[TASK] Add link to changelog for deprecated flex form section usage

### DIFF
--- a/Documentation/ColumnsConfig/Type/Flex/FlexformSyntax.rst
+++ b/Documentation/ColumnsConfig/Type/Flex/FlexformSyntax.rst
@@ -34,7 +34,8 @@ documented here for TCA. The limitations are:
     Since TYPO3 13.0, also :php:`type='select'` (when using
     :php:`foreign_table`) is not allowed and will raise an exception
     when used. Note this only applies to FlexForm sections, not general
-    FlexForm usage.
+    FlexForm usage. For details and migration see 
+    :ref:`Breaking: #102970 - No database relations in FlexForm container sections <changelog:breaking-102970-1706447911>`.
 
 The tables below documents the extension elements:
 


### PR DESCRIPTION
Resolves https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/841 Releases: main