### PR TITLE
Prefer LinkFactory::createUri() for pure URI creation

### DIFF
--- a/Documentation/ColumnsConfig/Type/Link/_Snippets/_SomeService.php
+++ b/Documentation/ColumnsConfig/Type/Link/_Snippets/_SomeService.php
@@ -14,11 +14,7 @@ class SomeService
     public function getUri(string $tcaLinkValue, ContentObjectRenderer $contentObjectRenderer): string
     {
         return $this->linkFactory->createUri(
-            '',
-            [
-                'parameter'        => $tcaLinkValue,
-                'forceAbsoluteUrl' => true,
-            ],
+            $tcaLinkValue,
             $contentObjectRenderer
         );
     }

--- a/Documentation/ColumnsConfig/Type/Link/_Snippets/_SomeService.php
+++ b/Documentation/ColumnsConfig/Type/Link/_Snippets/_SomeService.php
@@ -11,9 +11,9 @@ class SomeService
         private readonly LinkFactory $linkFactory,
     ) {}
 
-    public function getLink(string $tcaLinkValue, ContentObjectRenderer $contentObjectRenderer): string
+    public function getUri(string $tcaLinkValue, ContentObjectRenderer $contentObjectRenderer): string
     {
-        $link = $this->linkFactory->create(
+        return $this->linkFactory->createUri(
             '',
             [
                 'parameter'        => $tcaLinkValue,
@@ -21,6 +21,5 @@ class SomeService
             ],
             $contentObjectRenderer
         );
-        return $link->getUrl();
     }
 }


### PR DESCRIPTION
The given example does not make much sense if nothing besides the URL/URI is used from a link