### PR TITLE
[BUGFIX] Avoid new paragraph in note for input's "max"

### DIFF
--- a/Documentation/ColumnsConfig/Type/Input/_Properties/_Max.rst.txt
+++ b/Documentation/ColumnsConfig/Type/Input/_Properties/_Max.rst.txt
@@ -11,5 +11,5 @@
 
     If the form element edits a varchar(40) field in the database you should also set this value to 40.
 
-    ..  note:: If you reduce this value and there is already content longer then :confval:`input-max` the input will
-        be cropped without notice on saving.
+    ..  note::
+        If you reduce this value and there is already content longer then :confval:`input-max` the input will be cropped without notice on saving.


### PR DESCRIPTION
Releases: main, 12.4