### PR TITLE
[TASK] Deprecate plugin content element and plugin subtypes (list_type)

### DIFF
--- a/Documentation/ColumnsConfig/Type/Flex/AboutDataStructures.rst
+++ b/Documentation/ColumnsConfig/Type/Flex/AboutDataStructures.rst
@@ -25,13 +25,13 @@ One data structure only
     'config' => [
         'type' => 'flex',
         'ds' => [
-            'default' => 'FILE:EXT:myextension/Configuration/FlexForms/Main.xml',
+            'default' => 'FILE:EXT:my_extension/Configuration/FlexForms/Main.xml',
         ],
     ],
 
 Straight and simple: Whenever a record is handled that has a column field
 definition with this TCA, the data structure defined in
-:file:`FILE:EXT:myextension/Configuration/FlexForms/Main.xml`
+:file:`FILE:EXT:my_extension/Configuration/FlexForms/Main.xml`
 is parsed and the flex form defined in there is displayed.
 
 
@@ -44,9 +44,9 @@ Data structure selection depends on a field value
         'type' => 'flex',
         'ds_pointerField' => 'selector'
         'ds' => [
-            'default' => 'FILE:EXT:myextension/Configuration/FlexForms/Default.xml',
-            'foo' => 'FILE:EXT:myextension/Configuration/FlexForms/Foo.xml',
-            'bar' => 'FILE:EXT:myextension/Configuration/FlexForms/Bar.xml',
+            'default' => 'FILE:EXT:my_extension/Configuration/FlexForms/Default.xml',
+            'foo' => 'FILE:EXT:my_extension/Configuration/FlexForms/Foo.xml',
+            'bar' => 'FILE:EXT:my_extension/Configuration/FlexForms/Bar.xml',
         ],
     ],
 
@@ -55,29 +55,3 @@ depends on the **value** of the field "selector" which one is chosen: If
 "selector" value is "foo", "Foo.xml" is parsed and displayed, "Bar.xml" is
 chosen for the value "bar", and if none of the two matches, it falls back
 to "Default.xml".
-
-
-Data structure selection depends on a combination of two field values
-=====================================================================
-
-..  code-block:: php
-
-    'config' => [
-        'type' => 'flex',
-        'ds_pointerField' => 'list_type,CType',
-        'ds' => [
-            'default' => 'FILE:...',
-            'tt_address_pi1,list' => 'FILE:EXT:tt_address/pi1/flexform.xml',
-            '*,table' => 'FILE:EXT:css_styled_content/flexform_ds.xml',
-            'tx_myext_pi1' => 'FILE:EXT:myext/flexform.xml',
-        ],
-    ],
-
-The data structure selection now depends on the values of two different fields. First, there is a general "default"
-fallback if nothing else matches. Next, if field "list_type" has the value "tt_address_pi1" and "CType" has the value
-"list", then the data structure defined in sub array "tt_address_pi1,list" is chosen. If "list_type" is anything, but
-"CType" is "table", then the data structure defined in "\*,table" is selected. And last, if "list_type" is "tx_myext_pi1"
-and "CType" is whatever else, then data structure "tx_myext_pi1" is used.
-
-This lookup mechanism is pretty powerful and used for instance in core for data structure selection depending
-on a selected "tt_content" element plugin.

--- a/Documentation/ColumnsConfig/Type/Select/Properties/ItemGroups.rst
+++ b/Documentation/ColumnsConfig/Type/Select/Properties/ItemGroups.rst
@@ -69,7 +69,7 @@ handled via placeholder ``--div--`` items,
 which then rendered as :html:`<optgroup>` HTML elements in a dropdown.
 
 In larger installations or TYPO3 instances with lots of extensions, Plugins
-(:php:`tt_content.list_type`), Content Types (:php:`tt_content.CType`) or custom
+or Content Types (:php:`tt_content.CType`), or custom
 Page Types (:php:`pages.doktype`) drop down lists could grow large and
 adding item groups caused tedious work for developers or integrators.
 Grouping can now be configured on a per-item


### PR DESCRIPTION
Remove further mentioning of the list_type not covered by #1182

Reference: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/1071
Releases: main