### PR TITLE
Update description of DateTime nullable option

### DIFF
--- a/Documentation/ColumnsConfig/Type/Datetime/_Properties/_Nullable.rst.txt
+++ b/Documentation/ColumnsConfig/Type/Datetime/_Properties/_Nullable.rst.txt
@@ -7,10 +7,7 @@
     :Default: false
     :Scope: Proc
 
-    If set to true, a checkbox will appear, which by default deactivates the
-    field. In the deactivated state the field is saved as :sql:`NULL` in the
-    database. By activating the checkbox it is possible to set a value.
-    If nothing is entered into the field, then an empty string will be saved and not a :sql:`NULL`.
+    If nothing is entered into the field, then it will be saved as :sql:`NULL`.
 
     The database field must allow the :sql:`NULL` value.
 


### PR DESCRIPTION
See: 87294: [BUGFIX] Remove inconvenient nullable checkbox from datetime elements | https://review.typo3.org/c/Packages/TYPO3.CMS/+/87294

Releases: main, 13.4, 12.4