### PR TITLE
fix: format code block for none type correctly

### DIFF
--- a/Documentation/ColumnsConfig/Type/None/_Properties/_Format.rst.txt
+++ b/Documentation/ColumnsConfig/Type/None/_Properties/_Format.rst.txt
@@ -74,6 +74,7 @@
             field's value as parameters.
 
 Examples
+
 ..  code-block:: php
 
     'aField' => [


### PR DESCRIPTION
Releases: main, 13.4, 12.4