### PR TITLE
[BUGFIX] For TCA type=link the TCA option is allowedFileExtensions

### DIFF
--- a/Documentation/ColumnsConfig/Type/Link/_Properties/_Appearance.rst.txt
+++ b/Documentation/ColumnsConfig/Type/Link/_Properties/_Appearance.rst.txt
@@ -72,7 +72,7 @@
                 'allowedOptions' => ['body', 'cc'],
             ],
 
-    allowedExtensions (array)
+    allowedFileExtensions (array)
 
         An array of allowed file extensions. To allow all extensions, skip this
         configuration or set it to :php:`['*']`. It's not possible to deny all
@@ -82,14 +82,14 @@
 
             // Allow only jpg and png file extensions
             'appearance' => [
-                'allowedExtensions' => ['jpg', 'png'],
+                'allowedFileExtensions' => ['jpg', 'png'],
             ],
 
         ..  code-block:: php
 
             // Allow all file extensions (or skip this option).
             'appearance' => [
-                'allowedExtensions' => ['*'],
+                'allowedFileExtensions' => ['*'],
             ],
 
 


### PR DESCRIPTION
fixes #1224

Releases: main, 13.4, 12.4