### PR TITLE
[FEATURE] Associative array keys for TCA valuePicker items

### DIFF
--- a/Documentation/ColumnsConfig/Type/Color/_Properties/_ValuePicker.php
+++ b/Documentation/ColumnsConfig/Type/Color/_Properties/_ValuePicker.php
@@ -8,7 +8,10 @@ $temporaryColumns['aColorField'] = [
         'size' => 20,
         'valuePicker' => [
             'items' => [
-                ['typo3 orange', '#FF8700'],
+                [
+                    'label' => 'TYPO3 orange',
+                    'value' => '#FF8700',
+                ],
             ],
         ],
     ],

--- a/Documentation/ColumnsConfig/Type/Color/_Properties/_ValuePicker.rst.txt
+++ b/Documentation/ColumnsConfig/Type/Color/_Properties/_ValuePicker.rst.txt
@@ -7,7 +7,12 @@
     :Scope: Display
 
     Renders a select box with static values next to the input field. When a
-    value is selected in the box, the value is transferred to the field. Keys:
+    value is selected in the box, the value is transferred to the field.
+
+    ..  versionchanged:: 14.0
+        It is now possible to define associative array keys for the :php:`items`
+        configuration of TCA configuration :php:`valuePicker`. The
+        new keys are called: :php:`label` and :php:`value`.
 
     items (array)
         An array with selectable items. Each item is an array with the first value being the label in the select

--- a/Documentation/ColumnsConfig/Type/Input/_Properties/_ValuePicker.rst.txt
+++ b/Documentation/ColumnsConfig/Type/Input/_Properties/_ValuePicker.rst.txt
@@ -17,6 +17,11 @@
         prepend
             The selected value is prepended to an existing value of the input field
 
+    ..  versionchanged:: 14.0
+        It is now possible to define associative array keys for the :php:`items`
+        configuration of TCA configuration :php:`valuePicker`. The
+        new keys are called: :php:`label` and :php:`value`.
+
     items (array)
         An array with selectable items. Each item is an array with the first value being the label in the select
         drop-down (LLL reference possible) the second being the value transferred to the input field.

--- a/Documentation/ColumnsConfig/Type/Link/_Properties/_ValuePicker.rst.txt
+++ b/Documentation/ColumnsConfig/Type/Link/_Properties/_ValuePicker.rst.txt
@@ -17,6 +17,11 @@
         prepend
             The selected value is prepended to an existing value of the input field
 
+    ..  versionchanged:: 14.0
+        It is now possible to define associative array keys for the :php:`items`
+        configuration of TCA configuration :php:`valuePicker`. The
+        new keys are called: :php:`label` and :php:`value`.
+
     items (array)
         An array with selectable items. Each item is an array with the first value being the label in the select
         drop-down (LLL reference possible) the second being the value transferred to the input field.

--- a/Documentation/ColumnsConfig/Type/Link/_Snippets/_valuePicker.php
+++ b/Documentation/ColumnsConfig/Type/Link/_Snippets/_valuePicker.php
@@ -7,8 +7,14 @@ $myLinkField = [
         'mode' => 'prepend',
         'valuePicker' => [
             'items' => [
-                ['HTTPS', 'https://'],
-                ['HTTP', 'http://'],
+                [
+                    'value' => 'HTTPS',
+                    'label' => 'https://',
+                ],
+                [
+                    'value' => 'HTTP',
+                    'label' => 'http://',
+                ],
             ],
         ],
     ],

--- a/Documentation/ColumnsConfig/Type/Number/_Properties/_ValuePicker.php
+++ b/Documentation/ColumnsConfig/Type/Number/_Properties/_ValuePicker.php
@@ -7,8 +7,14 @@ $temporaryColumns['numberField'] = [
         'mode' => '',
         'valuePicker' => [
             'items' => [
-                ['One', '1'],
-                ['Two', '2'],
+                [
+                    'label' => 'One',
+                    'value' => '1',
+                ],
+                [
+                    'label' => 'Two',
+                    'value' => '2',
+                ],
             ],
         ],
     ],


### PR DESCRIPTION
Resolves: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/1222
Releases: main