### PR TITLE
Update hint about TCA:fieldInformation

### DIFF
--- a/Documentation/ColumnsConfig/CommonProperties/FieldInformation.rst
+++ b/Documentation/ColumnsConfig/CommonProperties/FieldInformation.rst
@@ -22,8 +22,10 @@ fieldInformation
 
 ..  hint::
 
-    :php:`fieldInformation` is not implemented by default. Use :ref:`columns-properties-description`
-    to display general information below a fields title.
+    Currently, :php:`fieldInformation` is implement for all form elements,
+    except in cases where it does not make sense. You can use
+    :ref:`description <columns-properties-description>` to display general
+    information between a fields title and the form element itself.
 
 Example
 =======


### PR DESCRIPTION
The description in docs CoreAPI tells something different as written here. It say that all these three extending features are implemented for nearly all form fields. I have updated that part here and repaired the defect :ref: link