### PR TITLE
[TASK] Drop "foreign_table" TCA extbase requirement on type=group

### DIFF
--- a/Documentation/ColumnsConfig/Type/Group/_Properties/_ForeignTable.rst.txt
+++ b/Documentation/ColumnsConfig/Type/Group/_Properties/_ForeignTable.rst.txt
@@ -6,8 +6,16 @@
     :type: string (table name)
     :Scope: Proc. / Display
 
-    This property does not really exist for group-type fields. It is needed as
-    a workaround for an Extbase limitation. It is used to resolve dependencies
+    ..  tip::
+        ..  versionadded:: 13.4.10
+            Starting with TYPO3 13.4.10, this option is no longer needed.
+            For extbase, the proper type is inferred from the first entry
+            in the `allowed  <https://docs.typo3.org/permalink/t3tca:confval-group-allowed>`_
+            TCA configuration option. You should only set this option if you
+            need backward compatibility to previous TYPO3 versions.
+
+    This property does not really exist for group-type fields. It was needed as
+    a workaround for an Extbase limitation. It was used to resolve dependencies
     during Extbase persistence. It should hold the same values as property
     :ref:`allowed <columns-group-properties-allowed>`. Notice that only one
     table name is allowed here in contrast to the property

--- a/Documentation/ColumnsConfig/Type/Group/_Properties/_ForeignTable.rst.txt
+++ b/Documentation/ColumnsConfig/Type/Group/_Properties/_ForeignTable.rst.txt
@@ -9,7 +9,7 @@
     ..  tip::
         ..  versionchanged:: 13.4.10
             Starting with TYPO3 13.4.10, this option is no longer needed.
-            For extbase, the proper type is inferred from the first entry
+            For Extbase, the proper type is inferred from the first entry
             in the `allowed  <https://docs.typo3.org/permalink/t3tca:confval-group-allowed>`_
             TCA configuration option. You should only set this option if you
             need backward compatibility to previous TYPO3 versions.

--- a/Documentation/ColumnsConfig/Type/Group/_Properties/_ForeignTable.rst.txt
+++ b/Documentation/ColumnsConfig/Type/Group/_Properties/_ForeignTable.rst.txt
@@ -7,7 +7,7 @@
     :Scope: Proc. / Display
 
     ..  tip::
-        ..  versionadded:: 13.4.10
+        ..  versionchanged:: 13.4.10
             Starting with TYPO3 13.4.10, this option is no longer needed.
             For extbase, the proper type is inferred from the first entry
             in the `allowed  <https://docs.typo3.org/permalink/t3tca:confval-group-allowed>`_


### PR DESCRIPTION
Patch https://review.typo3.org/c/Packages/TYPO3.CMS/+/88898 was merged and release in 13.4.10. This makes the option obsolete, unless BC is needed.