### PR TITLE
[BUGFIX] group localizeReferencesAtParentLocalization with allowed

### DIFF
--- a/Documentation/ColumnsConfig/Type/Group/_Properties/_LocalizeReferencesAtParentLocalization.rst.txt
+++ b/Documentation/ColumnsConfig/Type/Group/_Properties/_LocalizeReferencesAtParentLocalization.rst.txt
@@ -8,5 +8,4 @@
 
     Defines whether referenced records should be localized when the current
     record gets localized. This only applies if references are **not** stored using
-    `MM` tables. :ref:`foreign_table <columns-group-properties-foreign-table>`
-    has to reference the same table in :ref:`allowed <columns-group-properties-allowed>`.
+    `MM` tables.


### PR DESCRIPTION
This has been relaxed in core with
https://forge.typo3.org/issues/41713
https://review.typo3.org/c/Packages/TYPO3.CMS/+/72102