### PR TITLE
Add a note about DI in custom form inputs

### DIFF
--- a/Documentation/ColumnsConfig/Type/User/Index.rst
+++ b/Documentation/ColumnsConfig/Type/User/Index.rst
@@ -52,8 +52,20 @@ implementing a rendering. See :ref:`FormEngine docs
 
 ..  rst-class:: bignums
 
+1.  Verify Extension Compatibility with Dependency Injection (DI)
 
-1.  Register the new renderType node element
+    ..  versionchanged:: 13.0
+
+        Form Elements are now instantiated using Dependency Injection (DI).
+        Therefore, ensure your TYPO3 extension includes a properly
+        configured :file:`Configuration/Services.yaml` file.
+
+    Make sure your extension contains a `Configuration/Services.yaml` file with
+    the minimal configuration. For the minimal content, see the section about
+    :ref:`Services.yaml declaring service defaults <https://docs.typo3.org/permalink/t3coreapi:dependency-injection-in-extensions>`_
+    in the TYPO3 documentation.
+
+2.  Register the new renderType node element
 
     Add to :file:`ext_localconf.php`:
 
@@ -67,7 +79,7 @@ implementing a rendering. See :ref:`FormEngine docs
         ];
 
 
-2.  Use the renderType in a TCA field definition
+3.  Use the renderType in a TCA field definition
 
     Add the field to the TCA definition, here in
     :file:`Configuration/TCA/Overrides/fe_users.php`:
@@ -75,7 +87,7 @@ implementing a rendering. See :ref:`FormEngine docs
     ..  literalinclude:: _includes/_fe_users.php
         :caption: EXT:my_extension/Configuration/TCA/Overrides/fe_users.php
 
-3.  Implement the FormElement class
+4.  Implement the FormElement class
 
     The :php:`renderType` can be implemented by extending the class
     :php:`AbstractFormElement` and overriding the function :php:`render()`:

--- a/Documentation/ColumnsConfig/Type/User/Index.rst
+++ b/Documentation/ColumnsConfig/Type/User/Index.rst
@@ -61,7 +61,7 @@ implementing a rendering. See :ref:`FormEngine docs
         Therefore, ensure your TYPO3 extension includes a properly
         configured :file:`Configuration/Services.yaml` file.
 
-    Make sure your extension contains a `Configuration/Services.yaml` file with
+    Make sure your extension contains a :file:`Configuration/Services.yaml` file with
     the minimal configuration. For the minimal content, see the section about
     `Services.yaml declaring service defaults <https://docs.typo3.org/permalink/t3coreapi:dependency-injection-in-extensions>`_
     in the TYPO3 documentation.

--- a/Documentation/ColumnsConfig/Type/User/Index.rst
+++ b/Documentation/ColumnsConfig/Type/User/Index.rst
@@ -62,7 +62,7 @@ implementing a rendering. See :ref:`FormEngine docs
 
     Make sure your extension contains a `Configuration/Services.yaml` file with
     the minimal configuration. For the minimal content, see the section about
-    :ref:`Services.yaml declaring service defaults <https://docs.typo3.org/permalink/t3coreapi:dependency-injection-in-extensions>`_
+    `Services.yaml declaring service defaults <https://docs.typo3.org/permalink/t3coreapi:dependency-injection-in-extensions>`_
     in the TYPO3 documentation.
 
 2.  Register the new renderType node element

--- a/Documentation/ColumnsConfig/Type/User/Index.rst
+++ b/Documentation/ColumnsConfig/Type/User/Index.rst
@@ -56,7 +56,8 @@ implementing a rendering. See :ref:`FormEngine docs
 
     ..  versionchanged:: 13.0
 
-        Form Elements are now instantiated using Dependency Injection (DI).
+        Form Elements are now instantiated using
+        `Dependency injection <https://docs.typo3.org/permalink/t3coreapi:dependency-injection>`_.
         Therefore, ensure your TYPO3 extension includes a properly
         configured :file:`Configuration/Services.yaml` file.
 


### PR DESCRIPTION
See https://forge.typo3.org/issues/106875#change-544592

The current docs do not mention that DI (Services.yaml with at least a minimal configuration) needs to be used.