### PR TITLE
[DOCS] Remove superfluous config example field

### DIFF
--- a/Documentation/CodeSnippets/GroupDb10.rst.txt
+++ b/Documentation/CodeSnippets/GroupDb10.rst.txt
@@ -11,7 +11,6 @@
                 'config' => [
                     'type' => 'group',
                     'allowed' => 'pages',
-                    'relationship' => 'manyToOne',
                     'minitems' => 0,
                     'size' => 1,
                     'suggestOptions' => [


### PR DESCRIPTION
The field `relationship` is not a valid property of the TCA column type `group` and should not be listed in the example code snippet.
