### PR TITLE
[TASK] Clarify rows/cols intent for TCA RTE fields

### DIFF
--- a/Documentation/ColumnsConfig/Type/Text/Default/_Properties/_Cols.rst.txt
+++ b/Documentation/ColumnsConfig/Type/Text/Default/_Properties/_Cols.rst.txt
@@ -9,7 +9,8 @@
     Abstract value for the width of the :code:`<textarea>` field. To set
     the textarea to the full width of the form area, use the value 50. Default is 30.
 
-    Does not apply to RTE fields.
+    Does not apply to RTE fields, is only applied to their initial
+    unrendered state.
 
 ..  rubric:: Example: A simple text editor with 2 rows
 

--- a/Documentation/ColumnsConfig/Type/Text/Default/_Properties/_Rows.rst.txt
+++ b/Documentation/ColumnsConfig/Type/Text/Default/_Properties/_Rows.rst.txt
@@ -13,7 +13,8 @@
     automatically be increased if the content in the field is found to be of a certain length, thus the
     field will automatically fit the content. Default is 5. Max value is 20.
 
-    Does not apply to RTE fields.
+    Does not apply to RTE fields, is only applied to their initial
+    unrendered state.
 
 ..  rubric:: A simple text editor with 2 rows
 

--- a/Documentation/ColumnsConfig/Type/Text/TextTable/_Properties/_Rows.rst.txt
+++ b/Documentation/ColumnsConfig/Type/Text/TextTable/_Properties/_Rows.rst.txt
@@ -11,7 +11,8 @@
     automatically be increased if the content in the field is found to be of a certain length, thus the
     field will automatically fit the content. Default is 5. Max value is 20.
 
-    Does not apply to RTE fields.
+    Does not apply to RTE fields, is only applied to their initial
+    unrendered state.
 
 ..  rubric:: Example: A simple text editor with 20 width
 


### PR DESCRIPTION
The TCA attribute is evaluated only for the initial HTML DOM rendering, but later will be re-styled by the RTE integration.

Related: https://forge.typo3.org/issues/109677
Releases: main, 14.3, 13.4