### PR TITLE
[DOCS] Update TCA link rel documentation for non-RTE context

### DIFF
--- a/Documentation/ColumnsConfig/Type/Link/_Properties/_Appearance.rst.txt
+++ b/Documentation/ColumnsConfig/Type/Link/_Properties/_Appearance.rst.txt
@@ -31,8 +31,14 @@
             The `title` attribute of the link
 
         rel
-            The link relationship. Only available for RTE enabled fields and if `buttons.link.relAttribute.enabled`
-            is enabled in the RTE YAML configuration.
+            The link relationship.
+
+            ..  versionchanged:: 14.2
+                No longer limited to RTE-enabled fields.
+
+            For RTE-enabled fields,
+            `buttons.link.relAttribute.enabled <https://docs.typo3.org/permalink/t3tsref:buttons-link-relattribute-enabled>`_,
+            must be enabled.
 
         ..  code-block:: php
 


### PR DESCRIPTION
Document that the `rel` option for `type=link` fields is no longer limited to RTE-enabled fields since TYPO3 v14.2.

Resolves: https://github.com/TYPO3-Documentation/TYPO3CMS-Reference-TCA/issues/1392
Releases: main, 14.3