### PR TITLE
[FEATURE] Hide FormEngine fields with no selectable items

### DIFF
--- a/Documentation/ColumnsConfig/Type/Category/_Properties/_ShowIfEmpty.rst.txt
+++ b/Documentation/ColumnsConfig/Type/Category/_Properties/_ShowIfEmpty.rst.txt
@@ -6,11 +6,11 @@
     :Default: false
 
     ..  versionchanged:: 14.2
-        Starting with TYPO3 14.2 relational fields are hidden when no selectable
-        items are available. This option can be used to disable the behaviour.
+        Starting with TYPO3, 14.2 relational fields are hidden when no
+        selectable items are available. Option `showIfEmpty` will disable this behaviour.
 
-    By default a field of type `category` is hidden when no categories are
-    available. Setting `showIfEmpty` to true, shows the field even if no options
+    By default, `category` fields are hidden when no categories are
+    available. Setting `showIfEmpty` to true displays this field type, even if no options
     are available.
 
     ..  code-block:: php
@@ -18,6 +18,6 @@
 
         $GLOBALS['TCA']['pages']['columns']['categories']['config']['showIfEmpty'] = true;
 
-    Possible reasons, why no categories are available: No category records
-    have been created yet, all categories have been deleted, or
-    the current user has no permissions for any of the existing categories.
+    Possible reasons why categories may not be available: no category records
+    have been created, all categories have been deleted, or
+    the current user has no permissions to access any of the categories.

--- a/Documentation/ColumnsConfig/Type/Category/_Properties/_ShowIfEmpty.rst.txt
+++ b/Documentation/ColumnsConfig/Type/Category/_Properties/_ShowIfEmpty.rst.txt
@@ -1,0 +1,23 @@
+..  confval:: showIfEmpty
+    :name: category-showIfEmpty
+    :Path: $GLOBALS['TCA'][$table]['columns'][$field]['config']['showIfEmpty']
+    :type: boolean
+    :Scope: Display
+    :Default: false
+
+    ..  versionchanged:: 14.2
+        Starting with TYPO3 14.2 relational fields are hidden when no selectable
+        items are available. This option can be used to disable the behaviour.
+
+    By default a field of type `category` is hidden when no categories are
+    available. Setting `showIfEmpty` to true, shows the field even if no options
+    are available.
+
+    ..  code-block:: php
+        :caption: EXT:my_extension/Configuration/TCA/Overrides/pages.php
+
+        $GLOBALS['TCA']['pages']['columns']['categories']['config']['showIfEmpty'] = true;
+
+    Possible reasons, why no categories are available: No category records
+    have been created yet, all categories have been deleted, or
+    the current user has no permissions for any of the existing categories.

--- a/Documentation/ColumnsConfig/Type/Language/Index.rst
+++ b/Documentation/ColumnsConfig/Type/Language/Index.rst
@@ -65,13 +65,13 @@ all languages from all site configurations are displayed in the new field.
     Fields of type `language` are now hidden by default if only one language is
     available.
 
-Fields of type `language` are hidden by default if only one language is
-available. They can be displayed nonetheless by setting
+`language` fields are hidden by default if only one language is
+available. If they should be displayed, set
 `showIfEmpty <https://docs.typo3.org/permalink/t3tca:confval-select-single-showIfEmpty>`_.
 
 Reasons why only one language is available include:
 
-*   Only one language has been configured in the
+*   Only one language has been configured in :doc:`Site Management <t3translate:SettingUpLanguages/Index#site-management>`
 
 
 ..  _columns-language-examples:

--- a/Documentation/ColumnsConfig/Type/Language/Index.rst
+++ b/Documentation/ColumnsConfig/Type/Language/Index.rst
@@ -61,6 +61,19 @@ types, except `pages`.
 In records on root level (`pid=0`) or on a page, outside of a site context,
 all languages from all site configurations are displayed in the new field.
 
+..  versionchanged:: 14.2
+    Fields of type `language` are now hidden by default if only one language is
+    available.
+
+Fields of type `language` are hidden by default if only one language is
+available. They can be displayed nonetheless by setting
+`showIfEmpty <https://docs.typo3.org/permalink/t3tca:confval-select-single-showIfEmpty>`_.
+
+Reasons why only one language is available include:
+
+*   Only one language has been configured in the
+
+
 ..  _columns-language-examples:
 ..  _columns-language-simple-example:
 

--- a/Documentation/ColumnsConfig/Type/Select/CheckBox/Index.rst
+++ b/Documentation/ColumnsConfig/Type/Select/CheckBox/Index.rst
@@ -124,3 +124,6 @@ Properties of the TCA column type `select` with renderType `selectCheckBox`
 
     ..  include:: _Properties/_ReadOnly.rst.txt
         :show-buttons:
+
+    ..  include:: _Properties/_ShowIfEmpty.rst.txt
+        :show-buttons:

--- a/Documentation/ColumnsConfig/Type/Select/CheckBox/_Properties/_ShowIfEmpty.rst.txt
+++ b/Documentation/ColumnsConfig/Type/Select/CheckBox/_Properties/_ShowIfEmpty.rst.txt
@@ -6,11 +6,11 @@
     :Default: false
 
     ..  versionchanged:: 14.2
-        Starting with TYPO3 14.2 relational fields are hidden when no selectable
-        items are available. This option can be used to disable the behaviour.
+        Starting with TYPO3 14.2, relational fields are hidden when no selectable
+        items are available. Option `showIfEmpty` will disable this behaviour.
 
-    By default a field of type `select` and any render type is hidden when no
-    select items are available. Setting `showIfEmpty` to true, shows the field
+    By default, `select` fields and any render types are hidden when no
+    select items are available. Setting `showIfEmpty` to true displays the field
     even if no options are available.
 
     ..  code-block:: php
@@ -18,18 +18,18 @@
 
         $GLOBALS['TCA']['pages']['columns']['some_select_field']['config']['showIfEmpty'] = true;
 
-    Possible reasons, why no select items are available:
+    Possible reasons why no select items are available:
 
-    *   `foreign_table <https://docs.typo3.org/permalink/t3tca:confval-select-checkbox-foreign-table>`_
-        was used and the referenced table has no records or none matching the
+    *   a `foreign_table <https://docs.typo3.org/permalink/t3tca:confval-select-checkbox-foreign-table>`_
+        is used and the referenced table has no records or none matching the
         `foreign_table_where <https://docs.typo3.org/permalink/t3tca:confval-select-checkbox-foreign-table-where>`_.
-    *   `foreign_table <https://docs.typo3.org/permalink/t3tca:confval-select-checkbox-foreign-table>`_
-        was used and the currently logged in user has not permissions for the
-        referenced table or all of it records.
-    *   All items have been hidden via page TSconfig, for example via
+    *   a `foreign_table <https://docs.typo3.org/permalink/t3tca:confval-select-checkbox-foreign-table>`_
+        is used and the currently logged in user has no permissions for the
+        referenced table or its records.
+    *   All items have been hidden via page TSconfig, for example,
         `removeItems <https://docs.typo3.org/permalink/t3tsref:tceform-removeitems>`_
         or `keepItems <https://docs.typo3.org/permalink/t3tsref:confval-tceform-keepitems>`_
-        is inproperly configured.
+        are inproperly configured.
     *   The `itemsProcessors <https://docs.typo3.org/permalink/t3tca:confval-select-checkbox-itemsprocessors>`_
         or `itemsProcFunc <https://docs.typo3.org/permalink/t3tca:confval-select-checkbox-itemsprocfunc>`_
         had no result.

--- a/Documentation/ColumnsConfig/Type/Select/CheckBox/_Properties/_ShowIfEmpty.rst.txt
+++ b/Documentation/ColumnsConfig/Type/Select/CheckBox/_Properties/_ShowIfEmpty.rst.txt
@@ -1,0 +1,35 @@
+..  confval:: showIfEmpty
+    :name: select-checkbox-showIfEmpty
+    :Path: $GLOBALS['TCA'][$table]['columns'][$field]['config']['showIfEmpty']
+    :type: boolean
+    :Scope: Display
+    :Default: false
+
+    ..  versionchanged:: 14.2
+        Starting with TYPO3 14.2 relational fields are hidden when no selectable
+        items are available. This option can be used to disable the behaviour.
+
+    By default a field of type `select` and any render type is hidden when no
+    select items are available. Setting `showIfEmpty` to true, shows the field
+    even if no options are available.
+
+    ..  code-block:: php
+        :caption: EXT:my_extension/Configuration/TCA/Overrides/pages.php
+
+        $GLOBALS['TCA']['pages']['columns']['some_select_field']['config']['showIfEmpty'] = true;
+
+    Possible reasons, why no select items are available:
+
+    *   `foreign_table <https://docs.typo3.org/permalink/t3tca:confval-select-checkbox-foreign-table>`_
+        was used and the referenced table has no records or none matching the
+        `foreign_table_where <https://docs.typo3.org/permalink/t3tca:confval-select-checkbox-foreign-table-where>`_.
+    *   `foreign_table <https://docs.typo3.org/permalink/t3tca:confval-select-checkbox-foreign-table>`_
+        was used and the currently logged in user has not permissions for the
+        referenced table or all of it records.
+    *   All items have been hidden via page TSconfig, for example via
+        `removeItems <https://docs.typo3.org/permalink/t3tsref:tceform-removeitems>`_
+        or `keepItems <https://docs.typo3.org/permalink/t3tsref:confval-tceform-keepitems>`_
+        is inproperly configured.
+    *   The `itemsProcessors <https://docs.typo3.org/permalink/t3tca:confval-select-checkbox-itemsprocessors>`_
+        or `itemsProcFunc <https://docs.typo3.org/permalink/t3tca:confval-select-checkbox-itemsprocfunc>`_
+        had no result.

--- a/Documentation/ColumnsConfig/Type/Select/MultipleSideBySide/_Properties/_ShowIfEmpty.rst.txt
+++ b/Documentation/ColumnsConfig/Type/Select/MultipleSideBySide/_Properties/_ShowIfEmpty.rst.txt
@@ -6,11 +6,11 @@
     :Default: false
 
     ..  versionchanged:: 14.2
-        Starting with TYPO3 14.2 relational fields are hidden when no selectable
-        items are available. This option can be used to disable the behaviour.
+        Starting with TYPO3 14.2, relational fields are hidden when no selectable
+        items are available. Option `showIfEmpty` will disable this behaviour.
 
-    By default a field of type `select` and any render type is hidden when no
-    select items are available. Setting `showIfEmpty` to true, shows the field
+    By default, `select` fields and any render types are hidden when no
+    select items are available. Setting `showIfEmpty` to true displays the field
     even if no options are available.
 
     ..  code-block:: php
@@ -18,18 +18,18 @@
 
         $GLOBALS['TCA']['pages']['columns']['some_select_field']['config']['showIfEmpty'] = true;
 
-    Possible reasons, why no select items are available:
+    Possible reasons why no select items are available:
 
-    *   `foreign_table <https://docs.typo3.org/permalink/t3tca:confval-select-byside-foreign-table>`_
-        was used and the referenced table has no records or none matching the
+    *   a `foreign_table <https://docs.typo3.org/permalink/t3tca:confval-select-byside-foreign-table>`_
+        is used and the referenced table has no records or none matching the
         `foreign_table_where <https://docs.typo3.org/permalink/t3tca:confval-select-byside-foreign-table-where>`_.
-    *   `foreign_table <https://docs.typo3.org/permalink/t3tca:confval-select-byside-foreign-table>`_
-        was used and the currently logged in user has not permissions for the
+    *   a `foreign_table <https://docs.typo3.org/permalink/t3tca:confval-select-byside-foreign-table>`_
+        is used and the currently logged in user has no permissions for the
         referenced table or all of it records.
-    *   All items have been hidden via page TSconfig, for example via
+    *   All items have been hidden via page TSconfig, for example,
         `removeItems <https://docs.typo3.org/permalink/t3tsref:tceform-removeitems>`_
         or `keepItems <https://docs.typo3.org/permalink/t3tsref:confval-tceform-keepitems>`_
-        is inproperly configured.
+        are inproperly configured.
     *   The `itemsProcessors <https://docs.typo3.org/permalink/t3tca:confval-select-byside-itemsprocessors>`_
         or `itemsProcFunc <https://docs.typo3.org/permalink/t3tca:confval-select-byside-itemsprocfunc>`_
         had no result.

--- a/Documentation/ColumnsConfig/Type/Select/MultipleSideBySide/_Properties/_ShowIfEmpty.rst.txt
+++ b/Documentation/ColumnsConfig/Type/Select/MultipleSideBySide/_Properties/_ShowIfEmpty.rst.txt
@@ -1,0 +1,35 @@
+..  confval:: showIfEmpty
+    :name: select-byside-showIfEmpty
+    :Path: $GLOBALS['TCA'][$table]['columns'][$field]['config']['showIfEmpty']
+    :type: boolean
+    :Scope: Display
+    :Default: false
+
+    ..  versionchanged:: 14.2
+        Starting with TYPO3 14.2 relational fields are hidden when no selectable
+        items are available. This option can be used to disable the behaviour.
+
+    By default a field of type `select` and any render type is hidden when no
+    select items are available. Setting `showIfEmpty` to true, shows the field
+    even if no options are available.
+
+    ..  code-block:: php
+        :caption: EXT:my_extension/Configuration/TCA/Overrides/pages.php
+
+        $GLOBALS['TCA']['pages']['columns']['some_select_field']['config']['showIfEmpty'] = true;
+
+    Possible reasons, why no select items are available:
+
+    *   `foreign_table <https://docs.typo3.org/permalink/t3tca:confval-select-byside-foreign-table>`_
+        was used and the referenced table has no records or none matching the
+        `foreign_table_where <https://docs.typo3.org/permalink/t3tca:confval-select-byside-foreign-table-where>`_.
+    *   `foreign_table <https://docs.typo3.org/permalink/t3tca:confval-select-byside-foreign-table>`_
+        was used and the currently logged in user has not permissions for the
+        referenced table or all of it records.
+    *   All items have been hidden via page TSconfig, for example via
+        `removeItems <https://docs.typo3.org/permalink/t3tsref:tceform-removeitems>`_
+        or `keepItems <https://docs.typo3.org/permalink/t3tsref:confval-tceform-keepitems>`_
+        is inproperly configured.
+    *   The `itemsProcessors <https://docs.typo3.org/permalink/t3tca:confval-select-byside-itemsprocessors>`_
+        or `itemsProcFunc <https://docs.typo3.org/permalink/t3tca:confval-select-byside-itemsprocfunc>`_
+        had no result.

--- a/Documentation/ColumnsConfig/Type/Select/Single/_Properties/_ShowIfEmpty.rst.txt
+++ b/Documentation/ColumnsConfig/Type/Select/Single/_Properties/_ShowIfEmpty.rst.txt
@@ -6,11 +6,11 @@
     :Default: false
 
     ..  versionchanged:: 14.2
-        Starting with TYPO3 14.2 relational fields are hidden when no selectable
-        items are available. This option can be used to disable the behaviour.
+        Starting with TYPO3 14.2, relational fields are hidden when no selectable
+        items are available. Option `showIfEmpty` will disable this behaviour.
 
-    By default a field of type `select` and any render type is hidden when no
-    select items are available. Setting `showIfEmpty` to true, shows the field
+    By default, `select` fields and any render types are hidden when no
+    select items are available. Setting `showIfEmpty` to true displays the field
     even if no options are available.
 
     ..  code-block:: php
@@ -18,18 +18,18 @@
 
         $GLOBALS['TCA']['pages']['columns']['some_select_field']['config']['showIfEmpty'] = true;
 
-    Possible reasons, why no select items are available:
+    Possible reasons why no select items are available:
 
-    *   `foreign_table <https://docs.typo3.org/permalink/t3tca:confval-select-single-foreign-table>`_
-        was used and the referenced table has no records or none matching the
+    *   a `foreign_table <https://docs.typo3.org/permalink/t3tca:confval-select-single-foreign-table>`_
+        is used and the referenced table has no records or none matching the
         `foreign_table_where <https://docs.typo3.org/permalink/t3tca:confval-select-single-foreign-table-where>`_.
-    *   `foreign_table <https://docs.typo3.org/permalink/t3tca:confval-select-single-foreign-table>`_
-        was used and the currently logged in user has not permissions for the
-        referenced table or all of it records.
-    *   All items have been hidden via page TSconfig, for example via
+    *   a `foreign_table <https://docs.typo3.org/permalink/t3tca:confval-select-single-foreign-table>`_
+        is used and the currently logged in user has no permissions for the
+        referenced table or its records.
+    *   All items have been hidden via page TSconfig, for example,
         `removeItems <https://docs.typo3.org/permalink/t3tsref:tceform-removeitems>`_
         or `keepItems <https://docs.typo3.org/permalink/t3tsref:confval-tceform-keepitems>`_
-        is inproperly configured.
+        are inproperly configured.
     *   The `itemsProcessors <https://docs.typo3.org/permalink/t3tca:confval-select-single-itemsprocessors>`_
         or `itemsProcFunc <https://docs.typo3.org/permalink/t3tca:confval-select-single-itemsprocfunc>`_
         had no result.

--- a/Documentation/ColumnsConfig/Type/Select/Single/_Properties/_ShowIfEmpty.rst.txt
+++ b/Documentation/ColumnsConfig/Type/Select/Single/_Properties/_ShowIfEmpty.rst.txt
@@ -1,0 +1,35 @@
+..  confval:: showIfEmpty
+    :name: select-single-showIfEmpty
+    :Path: $GLOBALS['TCA'][$table]['columns'][$field]['config']['showIfEmpty']
+    :type: boolean
+    :Scope: Display
+    :Default: false
+
+    ..  versionchanged:: 14.2
+        Starting with TYPO3 14.2 relational fields are hidden when no selectable
+        items are available. This option can be used to disable the behaviour.
+
+    By default a field of type `select` and any render type is hidden when no
+    select items are available. Setting `showIfEmpty` to true, shows the field
+    even if no options are available.
+
+    ..  code-block:: php
+        :caption: EXT:my_extension/Configuration/TCA/Overrides/pages.php
+
+        $GLOBALS['TCA']['pages']['columns']['some_select_field']['config']['showIfEmpty'] = true;
+
+    Possible reasons, why no select items are available:
+
+    *   `foreign_table <https://docs.typo3.org/permalink/t3tca:confval-select-single-foreign-table>`_
+        was used and the referenced table has no records or none matching the
+        `foreign_table_where <https://docs.typo3.org/permalink/t3tca:confval-select-single-foreign-table-where>`_.
+    *   `foreign_table <https://docs.typo3.org/permalink/t3tca:confval-select-single-foreign-table>`_
+        was used and the currently logged in user has not permissions for the
+        referenced table or all of it records.
+    *   All items have been hidden via page TSconfig, for example via
+        `removeItems <https://docs.typo3.org/permalink/t3tsref:tceform-removeitems>`_
+        or `keepItems <https://docs.typo3.org/permalink/t3tsref:confval-tceform-keepitems>`_
+        is inproperly configured.
+    *   The `itemsProcessors <https://docs.typo3.org/permalink/t3tca:confval-select-single-itemsprocessors>`_
+        or `itemsProcFunc <https://docs.typo3.org/permalink/t3tca:confval-select-single-itemsprocfunc>`_
+        had no result.

--- a/Documentation/ColumnsConfig/Type/Select/SingleBox/_Properties/_ShowIfEmpty.rst.txt
+++ b/Documentation/ColumnsConfig/Type/Select/SingleBox/_Properties/_ShowIfEmpty.rst.txt
@@ -1,0 +1,35 @@
+..  confval:: showIfEmpty
+    :name: select-singlebox-showIfEmpty
+    :Path: $GLOBALS['TCA'][$table]['columns'][$field]['config']['showIfEmpty']
+    :type: boolean
+    :Scope: Display
+    :Default: false
+
+    ..  versionchanged:: 14.2
+        Starting with TYPO3 14.2 relational fields are hidden when no selectable
+        items are available. This option can be used to disable the behaviour.
+
+    By default a field of type `select` and any render type is hidden when no
+    select items are available. Setting `showIfEmpty` to true, shows the field
+    even if no options are available.
+
+    ..  code-block:: php
+        :caption: EXT:my_extension/Configuration/TCA/Overrides/pages.php
+
+        $GLOBALS['TCA']['pages']['columns']['some_select_field']['config']['showIfEmpty'] = true;
+
+    Possible reasons, why no select items are available:
+
+    *   `foreign_table <https://docs.typo3.org/permalink/t3tca:confval-select-singlebox-foreign-table>`_
+        was used and the referenced table has no records or none matching the
+        `foreign_table_where <https://docs.typo3.org/permalink/t3tca:confval-select-singlebox-foreign-table-where>`_.
+    *   `foreign_table <https://docs.typo3.org/permalink/t3tca:confval-select-singlebox-foreign-table>`_
+        was used and the currently logged in user has not permissions for the
+        referenced table or all of it records.
+    *   All items have been hidden via page TSconfig, for example via
+        `removeItems <https://docs.typo3.org/permalink/t3tsref:tceform-removeitems>`_
+        or `keepItems <https://docs.typo3.org/permalink/t3tsref:confval-tceform-keepitems>`_
+        is inproperly configured.
+    *   The `itemsProcessors <https://docs.typo3.org/permalink/t3tca:confval-select-singlebox-itemsprocessors>`_
+        or `itemsProcFunc <https://docs.typo3.org/permalink/t3tca:confval-select-singlebox-itemsprocfunc>`_
+        had no result.

--- a/Documentation/ColumnsConfig/Type/Select/Tree/_Properties/_ShowIfEmpty.rst.txt
+++ b/Documentation/ColumnsConfig/Type/Select/Tree/_Properties/_ShowIfEmpty.rst.txt
@@ -1,0 +1,35 @@
+..  confval:: showIfEmpty
+    :name: select-tree-showIfEmpty
+    :Path: $GLOBALS['TCA'][$table]['columns'][$field]['config']['showIfEmpty']
+    :type: boolean
+    :Scope: Display
+    :Default: false
+
+    ..  versionchanged:: 14.2
+        Starting with TYPO3 14.2 relational fields are hidden when no selectable
+        items are available. This option can be used to disable the behaviour.
+
+    By default a field of type `select` and any render type is hidden when no
+    select items are available. Setting `showIfEmpty` to true, shows the field
+    even if no options are available.
+
+    ..  code-block:: php
+        :caption: EXT:my_extension/Configuration/TCA/Overrides/pages.php
+
+        $GLOBALS['TCA']['pages']['columns']['some_select_field']['config']['showIfEmpty'] = true;
+
+    Possible reasons, why no select items are available:
+
+    *   `foreign_table <https://docs.typo3.org/permalink/t3tca:confval-select-tree-foreign-table>`_
+        was used and the referenced table has no records or none matching the
+        `foreign_table_where <https://docs.typo3.org/permalink/t3tca:confval-select-tree-foreign-table-where>`_.
+    *   `foreign_table <https://docs.typo3.org/permalink/t3tca:confval-select-tree-foreign-table>`_
+        was used and the currently logged in user has not permissions for the
+        referenced table or all of it records.
+    *   All items have been hidden via page TSconfig, for example via
+        `removeItems <https://docs.typo3.org/permalink/t3tsref:tceform-removeitems>`_
+        or `keepItems <https://docs.typo3.org/permalink/t3tsref:confval-tceform-keepitems>`_
+        is inproperly configured.
+    *   The `itemsProcessors <https://docs.typo3.org/permalink/t3tca:confval-select-tree-itemsprocessors>`_
+        or `itemsProcFunc <https://docs.typo3.org/permalink/t3tca:confval-select-tree-itemsprocfunc>`_
+        had no result.

--- a/Documentation/ColumnsConfig/Type/Select/Tree/_Properties/_ShowIfEmpty.rst.txt
+++ b/Documentation/ColumnsConfig/Type/Select/Tree/_Properties/_ShowIfEmpty.rst.txt
@@ -6,11 +6,11 @@
     :Default: false
 
     ..  versionchanged:: 14.2
-        Starting with TYPO3 14.2 relational fields are hidden when no selectable
-        items are available. This option can be used to disable the behaviour.
+        Starting with TYPO3 14.2, relational fields are hidden when no selectable
+        items are available. Option `showIfEmpty` will disable this behaviour.
 
-    By default a field of type `select` and any render type is hidden when no
-    select items are available. Setting `showIfEmpty` to true, shows the field
+    By default, `select` fields and any render types are hidden when no
+    select items are available. Setting `showIfEmpty` to true displays the field
     even if no options are available.
 
     ..  code-block:: php
@@ -18,18 +18,18 @@
 
         $GLOBALS['TCA']['pages']['columns']['some_select_field']['config']['showIfEmpty'] = true;
 
-    Possible reasons, why no select items are available:
+    Possible reasons why no select items are available:
 
-    *   `foreign_table <https://docs.typo3.org/permalink/t3tca:confval-select-tree-foreign-table>`_
-        was used and the referenced table has no records or none matching the
+    *   a `foreign_table <https://docs.typo3.org/permalink/t3tca:confval-select-tree-foreign-table>`_
+        is used and the referenced table has no records or none matching the
         `foreign_table_where <https://docs.typo3.org/permalink/t3tca:confval-select-tree-foreign-table-where>`_.
-    *   `foreign_table <https://docs.typo3.org/permalink/t3tca:confval-select-tree-foreign-table>`_
-        was used and the currently logged in user has not permissions for the
-        referenced table or all of it records.
-    *   All items have been hidden via page TSconfig, for example via
+    *   a `foreign_table <https://docs.typo3.org/permalink/t3tca:confval-select-tree-foreign-table>`_
+        is used and the currently logged in user has no permissions for the
+        referenced table or its records.
+    *   All items have been hidden via page TSconfig, for example,
         `removeItems <https://docs.typo3.org/permalink/t3tsref:tceform-removeitems>`_
         or `keepItems <https://docs.typo3.org/permalink/t3tsref:confval-tceform-keepitems>`_
-        is inproperly configured.
+        are inproperly configured.
     *   The `itemsProcessors <https://docs.typo3.org/permalink/t3tca:confval-select-tree-itemsprocessors>`_
         or `itemsProcFunc <https://docs.typo3.org/permalink/t3tca:confval-select-tree-itemsprocfunc>`_
         had no result.


### PR DESCRIPTION
Resolves: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/1672
Releases: main, 14.3