### PR TITLE
Bring back imageManipulation disable parameters

### DIFF
--- a/Documentation/ColumnsConfig/Type/ImageManipulation/Index.rst
+++ b/Documentation/ColumnsConfig/Type/ImageManipulation/Index.rst
@@ -143,6 +143,8 @@ Disable an aspect ratio
 
 Not only cropVariants but also aspect ratios can be disabled by adding a "disabled" key to the array.
 
+..  literalinclude:: _Snippets/_disabledAspectRatioCropVariant.php
+
 ..  _columns-imageManipulation-crop-variants-viewHelper:
 
 Crop variants in ViewHelpers

--- a/Documentation/ColumnsConfig/Type/ImageManipulation/Index.rst
+++ b/Documentation/ColumnsConfig/Type/ImageManipulation/Index.rst
@@ -125,6 +125,24 @@ It is also possible to set the cropping configuration only for a specific conten
 
 ..  literalinclude:: _Snippets/_overrideCropVariantsCType.php
 
+..  _columns-imageManipulation-crop-variants-disable:
+
+Disable a crop variant
+----------------------
+
+Please note, that while the array for ``overrideChildTca`` is merged with the child TCA, the crop variants replace those
+defined in the child TCA (most likely sys_file_reference), as long as the default configuration is in use.
+If however the crop variants have already been overriden in the child TCA, the crop variants are merged.
+Because you cannot remove crop variants easily, it is possible to disable them for certain field types by setting the
+array key for a crop variant ``disabled`` to the value ``true``
+
+..  _columns-imageManipulation-crop-variants-allowedAspectRatios:
+
+Disable an aspect ratio
+-----------------------
+
+Not only cropVariants but also aspect ratios can be disabled by adding a "disabled" key to the array.
+
 ..  _columns-imageManipulation-crop-variants-viewHelper:
 
 Crop variants in ViewHelpers

--- a/Documentation/ColumnsConfig/Type/ImageManipulation/Index.rst
+++ b/Documentation/ColumnsConfig/Type/ImageManipulation/Index.rst
@@ -133,6 +133,7 @@ Disable a crop variant
 Please note, that while the array for ``overrideChildTca`` is merged with the child TCA, the crop variants replace those
 defined in the child TCA (most likely sys_file_reference), as long as the default configuration is in use.
 If however the crop variants have already been overriden in the child TCA, the crop variants are merged.
+
 Because you cannot remove crop variants easily, it is possible to disable them for certain field types by setting the
 array key for a crop variant ``disabled`` to the value ``true``
 
@@ -141,7 +142,7 @@ array key for a crop variant ``disabled`` to the value ``true``
 Disable an aspect ratio
 -----------------------
 
-Not only cropVariants but also aspect ratios can be disabled by adding a "disabled" key to the array.
+Not only cropVariants but also aspect ratios can be disabled by adding a ``disabled`` key to the array.
 
 ..  literalinclude:: _Snippets/_disabledAspectRatioCropVariant.php
 


### PR DESCRIPTION
This section was removed as outdated with c84ee0c2bd432c594ab89984a126d6858abb7367 for TYPO3 13, as a override configuration now completely replaces the default configuration of cropVariants.

If however the configuration has already been overridden i.e. in 
```
$GLOBALS['TCA']['sys_file_reference']['columns']['crop']['config']['cropVariants']
```
the configurations are merged. So we still need this way to disable unwanted crop variants or aspect ratios...

The disable parameter still works in the core and is not deprecated, so this is merely a documentation issue.