### PR TITLE
[Backport 13.4] [TASK] Add headings to confval blocks without dedicated heading

### DIFF
--- a/Documentation/ColumnsConfig/CommonProperties/FieldControl/AddRecord.rst
+++ b/Documentation/ColumnsConfig/CommonProperties/FieldControl/AddRecord.rst
@@ -55,6 +55,11 @@ the table :sql:`be_groups`:
 Options
 =======
 
+..  _tca-property-field-control-add-record-options-disabled:
+
+disabled
+--------
+
 ..  confval:: disabled
     :name: fieldControl-addRecord-disabled
     :Path: $GLOBALS['TCA'][$table]['columns'][$field]['config']['fieldControl']['addRecord']
@@ -64,6 +69,11 @@ Options
 
     Disables the field control. Needs to be set to :php:`false` to enable the
     :guilabel:`Create new` button
+
+..  _tca-property-field-control-add-record-options-pid:
+
+options[pid]
+------------
 
 ..  confval:: options[pid]
     :name: fieldControl-addRecord-options-pid
@@ -84,6 +94,11 @@ Options
     -  :code:`###THIS_UID###`
     -  :code:`###SITEROOT###`
 
+..  _tca-property-field-control-add-record-options-table:
+
+options[table]
+--------------
+
 ..  confval:: options[table]
     :name: fieldControl-addRecord-options-table
     :Path: $GLOBALS['TCA'][$table]['columns'][$field]['config']['fieldControl']['addRecord']['options']
@@ -97,6 +112,11 @@ Options
     `type='group'` fields and to :ref:`foreign_table
     <columns-select-properties-foreign-table>` for `type='select'` fields.
 
+..  _tca-property-field-control-add-record-options-title:
+
+options[title]
+--------------
+
 ..  confval:: options[title]
     :name: fieldControl-addRecord-options-title
     :Path: $GLOBALS['TCA'][$table]['columns'][$field]['config']['fieldControl']['addRecord']['options']
@@ -106,6 +126,11 @@ Options
     :Default: LLL:EXT:core/Resources/Private/Language/locallang_core.xlf:labels.createNew
 
     Allows to set a different 'title' attribute to the popup icon.
+
+..  _tca-property-field-control-add-record-options-set-value:
+
+options[setValue]
+-----------------
 
 ..  confval:: options[setValue]
     :name: fieldControl-addRecord-options-setValue

--- a/Documentation/ColumnsConfig/CommonProperties/FieldControl/EditPopup.rst
+++ b/Documentation/ColumnsConfig/CommonProperties/FieldControl/EditPopup.rst
@@ -22,6 +22,11 @@ editPopup
 Options
 =======
 
+..  _tca-property-field-control-edit-popup-options-disabled:
+
+disabled
+--------
+
 ..  confval:: disabled
     :name: fieldControl-editPopup-disabled
     :Path: $GLOBALS['TCA'][$table]['columns'][$field]['config']['fieldControl']['editPopup']
@@ -32,6 +37,11 @@ Options
     Disables the field control. Needs to be set to :php:`false` to enable the
     :guilabel:`Create new` button
 
+..  _tca-property-field-control-edit-popup-options-title:
+
+options[title]
+--------------
+
 ..  confval:: options[title]
     :name: fieldControl-editPopup-options-title
     :Path: $GLOBALS['TCA'][$table]['columns'][$field]['config']['fieldControl']['editPopup']
@@ -41,6 +51,11 @@ Options
     :Default: LLL:EXT:core/Resources/Private/Language/locallang_core.xlf:labels.edit
 
     Allows to set a different 'title' attribute to the popup icon.
+
+..  _tca-property-field-control-edit-popup-options-window-open-parameters:
+
+options[windowOpenParameters]
+-----------------------------
 
 ..  confval:: options[windowOpenParameters]
     :name: fieldControl-editPopup-options-windowOpenParameters

--- a/Documentation/ColumnsConfig/CommonProperties/FieldControl/ListModule.rst
+++ b/Documentation/ColumnsConfig/CommonProperties/FieldControl/ListModule.rst
@@ -22,6 +22,11 @@ listModule
 Options
 =======
 
+..  _tca-property-field-control-list-module-options-disabled:
+
+disabled
+--------
+
 ..  confval:: disabled
     :name: fieldControl-listModule-disabled
     :Path: $GLOBALS['TCA'][$table]['columns'][$field]['config']['fieldControl']['listModule']
@@ -31,6 +36,11 @@ Options
 
     Disables the field control. Needs to be set to :php:`false` to enable the
     :guilabel:`Create new` button
+
+..  _tca-property-field-control-list-module-options-pid:
+
+options[pid]
+------------
 
 ..  confval:: options[pid]
     :name: fieldControl-listModule-options-pid
@@ -51,7 +61,12 @@ Options
     -  :code:`###THIS_UID###`
     -  :code:`###SITEROOT###`
 
-..  confval:: listModule options[table]
+..  _tca-property-field-control-list-module-options-table:
+
+options[table]
+--------------
+
+..  confval:: options[table]
     :name: fieldControl-listModule-options-table
     :Path: $GLOBALS['TCA'][$table]['columns'][$field]['config']['fieldControl']['listModule']
     :type: string
@@ -63,6 +78,11 @@ Options
     :ref:`allowed <columns-group-properties-allowed>` list if not set for
     `type='group'` fields and to :ref:`foreign_table
     <columns-select-properties-foreign-table>` for `type='select'` fields.
+
+..  _tca-property-field-control-list-module-options-title:
+
+options[title]
+--------------
 
 ..  confval:: options[title]
     :name: fieldControl-listModule-options-title

--- a/Documentation/ColumnsConfig/CommonProperties/Mm.rst
+++ b/Documentation/ColumnsConfig/CommonProperties/Mm.rst
@@ -40,12 +40,22 @@ element in a section.
 Related configurations
 ======================
 
+..  _columns-config-common-properties-mm-related-configurations-mm-match-fields:
+
+MM_match_fields
+---------------
+
 ..  confval:: MM_match_fields
     :type: array
     :Scope: Display / Proc.
 
     Array of field=>value pairs to both insert and match against when writing/reading MM relations.
 
+
+..  _columns-config-common-properties-mm-related-configurations-mm-opposite-field:
+
+MM_opposite_field
+-----------------
 
 ..  confval:: MM_opposite_field
     :type: string (field name)
@@ -62,6 +72,11 @@ Related configurations
         Bidirectional references only get registered once on the native side in "sys\_refindex".
 
 
+..  _columns-config-common-properties-mm-related-configurations-mm-opposite-usage:
+
+MM_oppositeUsage
+----------------
+
 ..  confval:: MM_oppositeUsage
     :type: array
     :Scope: Proc.
@@ -75,6 +90,11 @@ Related configurations
     references to the opposite side, so that they can be queried for match
     field configuration.
 
+
+..  _columns-config-common-properties-mm-related-configurations-mm-table-where:
+
+MM_table_where
+--------------
 
 ..  confval:: MM_table_where
     :type: string (SQL WHERE)


### PR DESCRIPTION
# Description
Backport of #1438 to `13.4`.

The automatic backport failed because `Documentation/404.rst` doesn't exist on the `13.4` branch (it only documents TYPO3 v14/v15-era removals, introduced on `main`/`14.3`). This backport drops that file's hunk and keeps the heading/anchor changes to `AddRecord.rst`, `EditPopup.rst`, `ListModule.rst`, and `Mm.rst`.